### PR TITLE
Add chromote as headless browser for testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,9 @@ jobs:
       - run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt install texlive texlive-fonts-extra -y
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
-
+-       with: 
+-        extra-packages: digest, RJSONIO, gtable, plyr, reshape2, scales, knitr, chromote
+-
       - name: install package
         run: R CMD INSTALL .
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,9 +28,9 @@ jobs:
       - run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt install texlive texlive-fonts-extra -y
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
--       with: 
--        extra-packages: digest, RJSONIO, gtable, plyr, reshape2, scales, knitr, chromote
--
+        with: 
+          extra-packages: digest, RJSONIO, gtable, plyr, reshape2, scales, knitr, chromote
+
       - name: install package
         run: R CMD INSTALL .
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,9 +28,7 @@ jobs:
       - run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt install texlive texlive-fonts-extra -y
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
-        with: 
-          extra-packages: digest, RJSONIO, gtable, plyr, reshape2, scales, knitr, chromote
-
+        
       - name: install package
         run: R CMD INSTALL .
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,9 +28,6 @@ jobs:
       - run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt install texlive texlive-fonts-extra -y
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
-        with: 
-          extra-packages: digest, RJSONIO, gtable, plyr, reshape2, scales, knitr, chromote
-
 
       - name: install package
         run: R CMD INSTALL .

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,12 +50,12 @@ Authors@R: c(
     person("Yufan", "Fei",
      role="aut",
      comment="Animint2 GSoC 2022"),
-	person("Jocelyne", "Chen",
-	 role="aut",
-	 comment="Animint2 GSoC 2023"),
-	 person("Siddhesh", "Deodhar",
-	 role="aut",
-	 comment="Animint2 GSoC 2024"))
+    person("Jocelyne", "Chen",
+     role="aut",
+     comment="Animint2 GSoC 2023"),
+    person("Siddhesh", "Deodhar",
+     role="aut",
+     comment="Animint2 GSoC 2024"))
 Description: Functions are provided for defining animated,
  interactive data visualizations in R code, and rendering
  on a web page. The 2018 Journal of Computational and 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Changes in version 2024.6.6 (PR#126)
  
-  - Add chromote as headless browser for testing
+  - Add chromote as headless browser for testing and remove phantomjs/firefox support
 
 # Changes in version 2024.3.12 (PR#119)
  

--- a/R/z_pages.R
+++ b/R/z_pages.R
@@ -47,7 +47,6 @@ animint2pages <- function(plot.list, github_repo, commit_message = "Commit from 
       stop(sprintf("Please run `install.packages('%s')` before using this function", pkg))
     }
   }
-
   # Generate plot files
   res <- animint2dir(plot.list, open.browser = FALSE, ...)
   # Select non-ignored files to post

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -39,13 +39,7 @@ if(filter == ""){
   filter <- NULL
 }
 message(gh.action)
-if(FALSE){
-  tests_init("firefox")
-}else if(interactive() | (gh.action == "ENABLED")) {
-  tests_init("chromote")
-} else {
-  tests_init()
-}
+tests_init()
 
 tests_run(filter=filter)
 tests_exit()

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -35,7 +35,7 @@ tests_init <- function(dir = ".", ...) {
   ex <- tests_exit()
   # start a non-blocking local file server under path/to/animint/tests/testhat
   testPath <- find_test_path(dir)
-  run_servr(port = "4848", directory = testPath)
+  run_servr(port = 4848, directory = testPath)
   # animint tests are performed in path/to/testthat/animint-htmltest/
   # note this path has to match the out.dir argument in animint2THML...
   testDir <- file.path(testPath, "animint-htmltest")

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -35,7 +35,7 @@ tests_init <- function(dir = ".", ...) {
   ex <- tests_exit()
   # start a non-blocking local file server under path/to/animint/tests/testhat
   testPath <- find_test_path(dir)
-  run_servr(port = port, directory = testPath)
+  run_servr(port = "4848", directory = testPath)
   # animint tests are performed in path/to/testthat/animint-htmltest/
   # note this path has to match the out.dir argument in animint2THML...
   testDir <- file.path(testPath, "animint-htmltest")

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -41,7 +41,6 @@ tests_init <- function(dir = ".", port = 4848, ...) {
   testDir <- file.path(testPath, "animint-htmltest")
   # if the htmltest directory exists, wipe clean, then create an empty folder
   unlink(testDir, recursive = TRUE)
-  
   chrome.session <- chromote::ChromoteSession$new()
   chrome.session$view()
   chrome.session$refresh <- function(){
@@ -51,8 +50,6 @@ tests_init <- function(dir = ".", port = 4848, ...) {
     # Block until p resolves
     chrome.session$wait_for(prom)
   }
-  
-  
   chrome.session$navigate <- function(u){
     chrome.session$Page$navigate(u)
     }
@@ -62,7 +59,6 @@ tests_init <- function(dir = ".", port = 4848, ...) {
     }
   remDr <<- chrome.session
   remDr$navigate(sprintf("http://localhost:4848/animint-htmltest/"))
-
   invisible(TRUE)
 }
 ## get both horizontal and vertical grid lines
@@ -86,3 +82,11 @@ sendKey <- function(key, code, keyCode) {
   remDr$Input$dispatchKeyEvent(type = "keyDown", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
   remDr$Input$dispatchKeyEvent(type = "keyUp", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
 }
+
+getClassBound <- function(geom.class, position){
+  script.txt <- sprintf(
+    'document.getElementsByClassName("%s")[0].getBoundingClientRect().%s', 
+    geom.class, position)
+  remDr$Runtime$evaluate(script.txt, returnByValue = TRUE)$result$value
+}
+

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -90,5 +90,4 @@ getClassBound <- function(geom.class, position){
     geom.class, position)
   Sys.sleep(2)
   runtime_evaluate(script=script.txt)
-  Sys.sleep(2)
 }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -82,7 +82,7 @@ sendKey <- function(key) {
   #The key codes in the list below are adopted from Windows Virtual keycode standards
   #https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
   # VK_BACK->Backspace, VK_RETURN->Enter, VK_DOWN->ArrowDown
-  # we use the decimal values of the key codes
+  # we use the corresponding decimal values of the key codes given in hex value in the above link
   key2code <- c(
     Backspace=8,
     Enter=13,

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -77,10 +77,14 @@ get_grid_lines <- function(html, p_name, grid_class){
   return(list(hor=attr_h, vert=attr_v))
 }
 # Function to send a key event
-sendKey <- function(key, code, keyCode) {
+sendKey <- function(key) {
   types <- c("keyDown", "keyUp")
+  key2code <- c(
+    Backspace=8,
+    Enter=13,
+    ArrowDown=40)
   for (type in types) {
-    remDr$Input$dispatchKeyEvent(type = type,key = key,code = code,windowsVirtualKeyCode = keyCode,nativeVirtualKeyCode = keyCode)
+    remDr$Input$dispatchKeyEvent(type = type, key = key, code = key, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = key2code[[key]])
   }
 }
 

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -30,7 +30,7 @@ getHTML <- function(){
 #' @export
 #' @seealso \link{tests_run}
 #'
-tests_init <- function(browserName = "chromote",dir = ".", port = 4848, ...) {
+tests_init <- function(dir = ".", port = 4848, ...) {
   # try to exit out of previously initated processes
   ex <- tests_exit()
   # start a non-blocking local file server under path/to/animint/tests/testhat

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -86,3 +86,9 @@ get_grid_lines <- function(html, p_name, grid_class){
   attr_v <- apply(attr_v, 2, as.numeric)
   return(list(hor=attr_h, vert=attr_v))
 }
+
+# Function to send a key event
+sendKey <- function(key, code, keyCode) {
+  remDr$Input$dispatchKeyEvent(type = "keyDown", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
+  remDr$Input$dispatchKeyEvent(type = "keyUp", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
+}

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -86,5 +86,6 @@ getClassBound <- function(geom.class, position){
   script.txt <- sprintf(
     'document.getElementsByClassName("%s")[0].getBoundingClientRect().%s', 
     geom.class, position)
+  Sys.sleep(2)
   runtime_evaluate(script=script.txt,return.value=TRUE)
 }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -30,7 +30,7 @@ getHTML <- function(){
 #' @export
 #' @seealso \link{tests_run}
 #'
-tests_init <- function(dir = ".", port = 4848, ...) {
+tests_init <- function(browserName = "chromote",dir = ".", port = 4848, ...) {
   # try to exit out of previously initated processes
   ex <- tests_exit()
   # start a non-blocking local file server under path/to/animint/tests/testhat
@@ -62,10 +62,7 @@ tests_init <- function(dir = ".", port = 4848, ...) {
     }
   remDr <<- chrome.session
   remDr$navigate(sprintf("http://localhost:4848/animint-htmltest/"))
-  
-  ## Why not just navigate to the right URL to begin with?
-  ## e <- remDr$findElement("xpath", "//a[@href='animint-htmltest/']")
-  ## e$clickElement()
+
   invisible(TRUE)
 }
 ## get both horizontal and vertical grid lines

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -90,4 +90,5 @@ getClassBound <- function(geom.class, position){
     geom.class, position)
   Sys.sleep(2)
   runtime_evaluate(script=script.txt)
+  Sys.sleep(2)
 }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -87,5 +87,5 @@ getClassBound <- function(geom.class, position){
     'document.getElementsByClassName("%s")[0].getBoundingClientRect().%s', 
     geom.class, position)
   Sys.sleep(2)
-  runtime_evaluate(script=script.txt,return.value=TRUE)
+  runtime_evaluate(script=script.txt)
 }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -76,19 +76,23 @@ get_grid_lines <- function(html, p_name, grid_class){
   attr_v <- apply(attr_v, 2, as.numeric)
   return(list(hor=attr_h, vert=attr_v))
 }
+### The hex codes come from
+### https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
+key2hex_code <- c(
+  Backspace="08",
+  Enter="0D",
+  ArrowDown="28")
+### https://chromedevtools.github.io/devtools-protocol/tot/Input/ says
+### that dispatchKeyEvent() requires DOM key codes (in decimal) for
+### the windowsVirtualKeyCode and nativeVirtualKeyCode arguments.
+key2dec_code <- structure(
+  strtoi(key2hex_code,base=16),
+  names=names(key2hex_code))
 # Function to send a key event
 sendKey <- function(key) {
   stopifnot(is.character(key))
-  #The key codes in the list below are adopted from Windows Virtual keycode standards
-  #https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
-  # VK_BACK->Backspace, VK_RETURN->Enter, VK_DOWN->ArrowDown
-  # we use the corresponding decimal values of the key codes given in hex value in the above link
-  key2code <- c(
-    Backspace=8,
-    Enter=13,
-    ArrowDown=40)
   for (type in c("keyDown", "keyUp")) {
-    remDr$Input$dispatchKeyEvent(type = type, key = key, code = key, windowsVirtualKeyCode = key2code[[key]], nativeVirtualKeyCode = key2code[[key]])
+    remDr$Input$dispatchKeyEvent(type = type, key = key, code = key, windowsVirtualKeyCode = key2dec_code[[key]], nativeVirtualKeyCode = key2dec_code[[key]])
   }
 }
 

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -76,7 +76,6 @@ get_grid_lines <- function(html, p_name, grid_class){
   attr_v <- apply(attr_v, 2, as.numeric)
   return(list(hor=attr_h, vert=attr_v))
 }
-
 # Function to send a key event
 sendKey <- function(key, code, keyCode) {
   remDr$Input$dispatchKeyEvent(type = "keyDown", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
@@ -90,3 +89,6 @@ getClassBound <- function(geom.class, position){
   remDr$Runtime$evaluate(script.txt, returnByValue = TRUE)$result$value
 }
 
+runtime_evaluate <- function(script=NULL,returnByValue=FALSE){
+  
+}

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -41,6 +41,7 @@ tests_init <- function(dir = ".", ...) {
   testDir <- file.path(testPath, "animint-htmltest")
   # if the htmltest directory exists, wipe clean, then create an empty folder
   unlink(testDir, recursive = TRUE)
+  options(chromote.timeout = 120)
   chrome.session <- chromote::ChromoteSession$new()
   chrome.session$view()
   chrome.session$refresh <- function(){

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -6,7 +6,7 @@ animint2HTML <- function(plotList) {
   res <- animint2dir(plotList, out.dir = "animint-htmltest",
                      open.browser = FALSE)
   remDr$refresh()
-  Sys.sleep(1)
+  Sys.sleep(2)
   res$html <- getHTML()
   ## [ERROR - 2019-06-05T18:30:55.358Z] Session [e7c4e500-871e-11e9-a9b5-8dab1f486f7e] - page.onError - msg: TypeError: 'undefined' is not an object (evaluating 's_info.type')
   ## [ERROR - 2019-06-05T18:30:55.360Z] Session [e7c4e500-871e-11e9-a9b5-8dab1f486f7e] - page.onError - stack:
@@ -47,12 +47,18 @@ tests_init <- function(dir = ".", port = 4848, ...) {
   if(OS == "Linux") {
     animint_server <- "localhost"   
   }
-  if(OS == "Windows" || OS == "Darwin") {
-    animint_server <- "host.docker.internal"
-  }
+  
   chrome.session <- chromote::ChromoteSession$new()
   chrome.session$view()
-  chrome.session$refresh <- function()chrome.session$Page$reload()
+  chrome.session$refresh <- function(){
+    ## from https://github.com/rstudio/chromote?tab=readme-ov-file#loading-a-page-reliably
+    prom <- chrome.session$Page$loadEventFired(wait_ = FALSE)  # Get the promise for the loadEventFired
+    chrome.session$Page$reload()
+    # Block until p resolves
+    chrome.session$wait_for(prom)
+  }
+  
+  
   chrome.session$navigate <- function(u){
     chrome.session$Page$navigate(u)
     }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -86,9 +86,5 @@ getClassBound <- function(geom.class, position){
   script.txt <- sprintf(
     'document.getElementsByClassName("%s")[0].getBoundingClientRect().%s', 
     geom.class, position)
-  remDr$Runtime$evaluate(script.txt, returnByValue = TRUE)$result$value
-}
-
-runtime_evaluate <- function(script=NULL,returnByValue=FALSE){
-  
+  runtime_evaluate(script=script.txt,return.value=TRUE)
 }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -30,7 +30,7 @@ getHTML <- function(){
 #' @export
 #' @seealso \link{tests_run}
 #'
-tests_init <- function(browserName = "phantomjs", dir = ".", port = 4848, ...) {
+tests_init <- function(dir = ".", port = 4848, ...) {
   # try to exit out of previously initated processes
   ex <- tests_exit()
   # start a non-blocking local file server under path/to/animint/tests/testhat
@@ -50,55 +50,19 @@ tests_init <- function(browserName = "phantomjs", dir = ".", port = 4848, ...) {
   if(OS == "Windows" || OS == "Darwin") {
     animint_server <- "host.docker.internal"
   }
-  if(browserName == "chromote"){
-    chrome.session <- chromote::ChromoteSession$new()
-    
-    chrome.session$view()
-    chrome.session$refresh <- function()chrome.session$Page$reload()
-    chrome.session$navigate <- function(u){
-      chrome.session$Page$navigate(u)
+  chrome.session <- chromote::ChromoteSession$new()
+  chrome.session$view()
+  chrome.session$refresh <- function()chrome.session$Page$reload()
+  chrome.session$navigate <- function(u){
+    chrome.session$Page$navigate(u)
     }
-    chrome.session$getPageSource <- function(){
-      doc <- chrome.session$DOM$getDocument()
-      chrome.session$DOM$getOuterHTML(doc$root$nodeId)$outerHTML
+  chrome.session$getPageSource <- function(){
+    doc <- chrome.session$DOM$getDocument()
+    chrome.session$DOM$getOuterHTML(doc$root$nodeId)$outerHTML
     }
-    remDr <<- chrome.session
-    remDr$browserName <-"chromote"
-    remDr$navigate(sprintf("http://localhost:4848/animint-htmltest/"))
-  }else{
-    if (browserName == "phantomjs") {
-      message("Starting phantomjs binary. To shut it down, run: \n pJS$stop()")
-      pJS <<- wdman::phantomjs(
-        port = remotePort,
-        phantomver = "latest"
-      )
-      ## Give time for phantomjs binary to start
-      animint_server <- "localhost"
-      Sys.sleep(8)  
-    } else if(browserName=="firefox"){
-      ## If using firefox, you'll need to run selenium-firefox docker image in order to make it work correctly.
-      ## We're using docker to avoid version incompatibility issues.
-      message("You need to run selenium docker image(selenium/standalone-firefox:2.53.0) as specified in docs(https://github.com/tdhock/animint2/wiki/Testing). \nNote: Ignore if already running.")
-    }else stop("unrecognized browser name")
-    remDr <<- RSelenium::remoteDriver(
-      port = remotePort,
-      browser = browserName,
-      )
-    ## wait for the remote driver to start-up
-    Sys.sleep(6)
-    remDr$open(silent = TRUE)
-    ## some tests don't run reliably with phantomjs (see tests-widerect.R)
-    Sys.setenv("ANIMINT_BROWSER" = browserName)
-    ## wait a maximum of 30 seconds when searchinsg for elements.
-    remDr$setTimeout(type = "implicit", milliseconds = 30000)
-    ## wait a maximum of 30 seconds for a particular type of operation to execute
-    remDr$setTimeout(type = "page load", milliseconds = 30000)
-    ## if we navigate to localhost:%s/htmltest directly, some browsers will
-    ## redirect to www.htmltest.com. A 'safer' approach is to navigate, then click.
-    remDr$browserName <-""
-    
-    remDr$navigate(sprintf("http://%s:%s/animint-htmltest/", animint_server, port))
-  }
+  remDr <<- chrome.session
+  remDr$navigate(sprintf("http://localhost:4848/animint-htmltest/"))
+  
   
   ## Why not just navigate to the right URL to begin with?
   ## e <- remDr$findElement("xpath", "//a[@href='animint-htmltest/']")

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -63,7 +63,6 @@ tests_init <- function(dir = ".", port = 4848, ...) {
   remDr <<- chrome.session
   remDr$navigate(sprintf("http://localhost:4848/animint-htmltest/"))
   
-  
   ## Why not just navigate to the right URL to begin with?
   ## e <- remDr$findElement("xpath", "//a[@href='animint-htmltest/']")
   ## e$clickElement()

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -30,7 +30,7 @@ getHTML <- function(){
 #' @export
 #' @seealso \link{tests_run}
 #'
-tests_init <- function(dir = ".", port = 4848, ...) {
+tests_init <- function(dir = ".", ...) {
   # try to exit out of previously initated processes
   ex <- tests_exit()
   # start a non-blocking local file server under path/to/animint/tests/testhat
@@ -58,7 +58,7 @@ tests_init <- function(dir = ".", port = 4848, ...) {
     chrome.session$DOM$getOuterHTML(doc$root$nodeId)$outerHTML
     }
   remDr <<- chrome.session
-  remDr$navigate(sprintf("http://localhost:4848/animint-htmltest/"))
+  remDr$navigate("http://localhost:4848/animint-htmltest/")
   invisible(TRUE)
 }
 ## get both horizontal and vertical grid lines

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -41,12 +41,6 @@ tests_init <- function(dir = ".", port = 4848, ...) {
   testDir <- file.path(testPath, "animint-htmltest")
   # if the htmltest directory exists, wipe clean, then create an empty folder
   unlink(testDir, recursive = TRUE)
-  # start-up remote driver
-  remotePort <- 4444L
-  OS <- Sys.info()[['sysname']]
-  if(OS == "Linux") {
-    animint_server <- "localhost"   
-  }
   
   chrome.session <- chromote::ChromoteSession$new()
   chrome.session$view()

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -79,6 +79,10 @@ get_grid_lines <- function(html, p_name, grid_class){
 # Function to send a key event
 sendKey <- function(key) {
   stopifnot(is.character(key))
+  #The key codes in the list below are adopted from Windows Virtual keycode standards
+  #https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+  # VK_BACK->Backspace, VK_RETURN->Enter, VK_DOWN->ArrowDown
+  # we use the decimal values of the key codes
   key2code <- c(
     Backspace=8,
     Enter=13,

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -78,12 +78,12 @@ get_grid_lines <- function(html, p_name, grid_class){
 }
 # Function to send a key event
 sendKey <- function(key) {
-  types <- c("keyDown", "keyUp")
+  stopifnot(is.character(key))
   key2code <- c(
     Backspace=8,
     Enter=13,
     ArrowDown=40)
-  for (type in types) {
+  for (type in c("keyDown", "keyUp")) {
     remDr$Input$dispatchKeyEvent(type = type, key = key, code = key, windowsVirtualKeyCode = key2code[[key]], nativeVirtualKeyCode = key2code[[key]])
   }
 }

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -84,7 +84,7 @@ sendKey <- function(key) {
     Enter=13,
     ArrowDown=40)
   for (type in types) {
-    remDr$Input$dispatchKeyEvent(type = type, key = key, code = key, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = key2code[[key]])
+    remDr$Input$dispatchKeyEvent(type = type, key = key, code = key, windowsVirtualKeyCode = key2code[[key]], nativeVirtualKeyCode = key2code[[key]])
   }
 }
 

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -78,8 +78,10 @@ get_grid_lines <- function(html, p_name, grid_class){
 }
 # Function to send a key event
 sendKey <- function(key, code, keyCode) {
-  remDr$Input$dispatchKeyEvent(type = "keyDown", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
-  remDr$Input$dispatchKeyEvent(type = "keyUp", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
+  types <- c("keyDown", "keyUp")
+  for (type in types) {
+    remDr$Input$dispatchKeyEvent(type = type,key = key,code = code,windowsVirtualKeyCode = keyCode,nativeVirtualKeyCode = keyCode)
+  }
 }
 
 getClassBound <- function(geom.class, position){

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -63,13 +63,10 @@ getSelectorWidgets <- function(html=getHTML()){
 }
 
 clickHTML <- function(...){
-  
   v <- c(...)
-  
   stopifnot(length(v) == 1)
   selectorValue <- as.character(v)
   clickID(selectorValue)  
-  
   Sys.sleep(1)
   getHTML()
 }
@@ -78,7 +75,7 @@ clickID <- function(...){
   v <- c(...)
   stopifnot(length(v) == 1)
   remDr$Runtime$evaluate(sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
-t}
+}
 
 rgba.pattern <- paste0(
   "(?<before>rgba?)",

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -74,7 +74,7 @@ clickHTML <- function(...){
 clickID <- function(...){
   v <- c(...)
   stopifnot(length(v) == 1)
-  remDr$Runtime$evaluate(sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
+  runtime_evaluate(script=sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
 }
 
 rgba.pattern <- paste0(
@@ -415,5 +415,13 @@ find_test_path <- function(dir = ".") {
                     tests = "testthat",
                     testthat = "")
   file.path(dir, ext_dir)
+}
+
+runtime_evaluate <- function(script=NULL,return.value=FALSE){
+  if (return.value){
+    value<- remDr$Runtime$evaluate(script,returnByValue = TRUE)$result$value
+  }else{
+    value<- remDr$Runtime$evaluate(script,returnByValue = TRUE)
+  }
 }
 

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -417,14 +417,10 @@ find_test_path <- function(dir = ".") {
   file.path(dir, ext_dir)
 }
 
-runtime_evaluate <- function(script=NULL,return.value=FALSE){
+runtime_evaluate <- function(script=NULL){
   
   eval.result<- remDr$Runtime$evaluate(script,returnByValue = TRUE)
-  if (return.value){
-    eval.result$result$value
-  }else{
-    eval.result
-  }
+  
 }
 
 runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dispatch_event=NULL, return.value=FALSE) {
@@ -441,5 +437,5 @@ runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dis
     script_template <- "document.getElementsByClassName('%s')[%d].dispatchEvent(new CustomEvent('click'));"
     script <- sprintf(script_template,class_name,list_num)
   }
-  runtime_evaluate(script = script, return.value = return.value)
+  runtime_evaluate(script = script)
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -419,7 +419,7 @@ find_test_path <- function(dir = ".") {
 
 runtime_evaluate <- function(script=NULL){
   
-  eval.result<- remDr$Runtime$evaluate(script,returnByValue = TRUE)$result$value
+  remDr$Runtime$evaluate(script,returnByValue = TRUE)$result$value
   
 }
 

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -419,11 +419,12 @@ find_test_path <- function(dir = ".") {
 
 runtime_evaluate <- function(script=NULL){
   
-  eval.result<- remDr$Runtime$evaluate(script,returnByValue = TRUE)
+  eval.result<- remDr$Runtime$evaluate(script,returnByValue = TRUE)$result$value
   
 }
 
 runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dispatch_event=NULL, return.value=FALSE) {
+  
   if(!is.null(class_name) && !is.null(id) && !is.null(dispatch_event)){
     script_template <- "div = document.getElementById('%s'); div.getElementsByClassName('%s')[%d].dispatchEvent(new CustomEvent('click'));"
     script <- sprintf(script_template, as.character(id), class_name, list_num)

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -418,9 +418,7 @@ find_test_path <- function(dir = ".") {
 }
 
 runtime_evaluate <- function(script=NULL){
-  
   remDr$Runtime$evaluate(script,returnByValue = TRUE)$result$value
-  
 }
 
 runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dispatch_event=NULL, return.value=FALSE) {

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -74,7 +74,7 @@ clickHTML <- function(...){
 clickID <- function(...){
   v <- c(...)
   stopifnot(length(v) == 1)
-  runtime_evaluate(script=sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
+  runtime_evaluate_helper(id=v,dispatch_event=TRUE)
 }
 
 rgba.pattern <- paste0(
@@ -426,3 +426,19 @@ runtime_evaluate <- function(script=NULL,return.value=FALSE){
   }
 }
 
+runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL,dispatch_event=NULL,return.value=FALSE) {
+  if(!is.null(class_name) && !is.null(id) && !is.null(dispatch_event)){
+    script_template <- "div = document.getElementById('%s'); div.getElementsByClassName('%s')[%d].dispatchEvent(new CustomEvent('click'));"
+    script <- sprintf(script_template, as.character(id), class_name, list_num)
+  }else if(is.null(class_name) && !is.null(id) && !is.null(dispatch_event)){
+    script_template <- "document.getElementById('%s').dispatchEvent(new CustomEvent('click'))"
+    script <- sprintf(script_template, as.character(id))
+  }else if(!is.null(class_name) && !is.null(id) && is.null(dispatch_event)){
+    script_template <- "div = document.getElementById('%s');div.getElementsByClassName('%s')[%d]"
+    script <- sprintf(script_template, as.character(id),class_name,list_num)
+  }else if(!is.null(class_name) && is.null(id) && !is.null(dispatch_event)){
+    script_template <- "document.getElementsByClassName('%s')[%d].dispatchEvent(new CustomEvent('click'));"
+    script <- sprintf(script_template,class_name,list_num)
+  }
+  runtime_evaluate(script = script, return.value = return.value)
+}

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -418,10 +418,11 @@ find_test_path <- function(dir = ".") {
 }
 
 runtime_evaluate <- function(script=NULL,return.value=FALSE){
+  eval.result<- remDr$Runtime$evaluate(script,returnByValue = TRUE)
   if (return.value){
-    value<- remDr$Runtime$evaluate(script,returnByValue = TRUE)$result$value
+    eval.result$result$value
   }else{
-    value<- remDr$Runtime$evaluate(script,returnByValue = TRUE)
+    eval.result
   }
 }
 

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -418,6 +418,7 @@ find_test_path <- function(dir = ".") {
 }
 
 runtime_evaluate <- function(script=NULL,return.value=FALSE){
+  
   eval.result<- remDr$Runtime$evaluate(script,returnByValue = TRUE)
   if (return.value){
     eval.result$result$value
@@ -426,7 +427,7 @@ runtime_evaluate <- function(script=NULL,return.value=FALSE){
   }
 }
 
-runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL,dispatch_event=NULL,return.value=FALSE) {
+runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dispatch_event=NULL, return.value=FALSE) {
   if(!is.null(class_name) && !is.null(id) && !is.null(dispatch_event)){
     script_template <- "div = document.getElementById('%s'); div.getElementsByClassName('%s')[%d].dispatchEvent(new CustomEvent('click'));"
     script <- sprintf(script_template, as.character(id), class_name, list_num)

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -67,17 +67,9 @@ clickHTML <- function(...){
   v <- c(...)
   
   stopifnot(length(v) == 1)
-  selectorType <- names(v)
   selectorValue <- as.character(v)
-
-  if (selectorType == "id") 
-    {
-    clickID(selectorValue)  
-  } 
-  else{
-  e <- remDr$findElement(names(v), as.character(v))
-  e$clickElement()
-  }
+  clickID(selectorValue)  
+  
   Sys.sleep(1)
   getHTML()
 }
@@ -85,14 +77,8 @@ clickHTML <- function(...){
 clickID <- function(...){
   v <- c(...)
   stopifnot(length(v) == 1)
-  if(remDr$browserName=="chromote"){
-    remDr$Runtime$evaluate(sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
-  }
-  else{
-    remDr$executeScript(sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
-  }
-  
-}
+  remDr$Runtime$evaluate(sprintf("document.getElementById('%s').dispatchEvent(new CustomEvent('click'))", as.character(v)))
+t}
 
 rgba.pattern <- paste0(
   "(?<before>rgba?)",

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -29,7 +29,9 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   expect_match(rotated["transform", ], paste0("rotate(", rotate), fixed=TRUE)
   # http://stackoverflow.com/questions/442404/retrieve-the-position-x-y-of-an-html-element
   tick_box <- getClassBound("xaxis", "bottom")
+  Sys.sleep(2)
   title_box <- getClassBound("xtitle", "top")
+  Sys.sleep(2)
   #An offset of 2.5 px is added in line below but it may need to changed slightly if browser environment is different.
   #more information of getBoundingClientRect() and why value it returns depends on specific browser environment is in the links below
   #https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -28,14 +28,8 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   expect_match(rotated["style", ], paste("text-anchor:", anchor), fixed=TRUE)
   expect_match(rotated["transform", ], paste0("rotate(", rotate), fixed=TRUE)
   # http://stackoverflow.com/questions/442404/retrieve-the-position-x-y-of-an-html-element
-  
-  
-  tick_box_script <- 'document.getElementsByClassName("xaxis")[0].getBoundingClientRect().bottom;'
-  title_box_script <- 'document.getElementsByClassName("xtitle")[0].getBoundingClientRect().top;'
-    
-  # Evaluate scripts and get the values
-  tick_box <- remDr$Runtime$evaluate(tick_box_script, returnByValue = TRUE)$result$value
-  title_box <- remDr$Runtime$evaluate(title_box_script, returnByValue = TRUE)$result$value
+  tick_box <- getClassBound("xaxis", "bottom")
+  title_box <- getClassBound("xtitle", "top")
   #An offset of 2.5 px is added in line below but it may need to changed slightly if browser environment is different.
   #more information of getBoundingClientRect() and why value it returns depends on specific browser environment is in the links below
   #https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -29,9 +29,7 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   expect_match(rotated["transform", ], paste0("rotate(", rotate), fixed=TRUE)
   # http://stackoverflow.com/questions/442404/retrieve-the-position-x-y-of-an-html-element
   tick_box <- getClassBound("xaxis", "bottom")
-  Sys.sleep(2)
   title_box <- getClassBound("xtitle", "top")
-  Sys.sleep(2)
   #An offset of 2.5 px is added in line below but it may need to changed slightly if browser environment is different.
   #more information of getBoundingClientRect() and why value it returns depends on specific browser environment is in the links below
   #https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -38,12 +38,6 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   title_box <- remDr$Runtime$evaluate(title_box_script, returnByValue = TRUE)$result$value
   #An offset of 2.5 is added because chromote aligns text with slight differences
   expect_true(title_box+2.5>= tick_box)
-  
-
-  
-  
-
-  
 }
 test_that('no axis rotation is fine', {
   map <-      

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -36,7 +36,10 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   # Evaluate scripts and get the values
   tick_box <- remDr$Runtime$evaluate(tick_box_script, returnByValue = TRUE)$result$value
   title_box <- remDr$Runtime$evaluate(title_box_script, returnByValue = TRUE)$result$value
-  #An offset of 2.5 is added because chromote aligns text with slight differences
+  #An offset of 2.5 px is added in line below but it may need to changed slightly if browser environment is different.
+  #more information of getBoundingClientRect() and why value it returns depends on specific browser environment is in the links below
+  #https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+  #https://stackoverflow.com/questions/40879171/in-javascript-why-does-getboundingclientrect-sometimes-return-floating-point
   expect_true(title_box+2.5>= tick_box)
 }
 test_that('no axis rotation is fine', {

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -34,7 +34,7 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   #more information of getBoundingClientRect() and why value it returns depends on specific browser environment is in the links below
   #https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
   #https://stackoverflow.com/questions/40879171/in-javascript-why-does-getboundingclientrect-sometimes-return-floating-point
-  expect_true(title_box+2.5>= tick_box)
+  expect_gt(title_box+2.5, tick_box)
 }
 test_that('no axis rotation is fine', {
   map <-      

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -29,22 +29,17 @@ expect_rotate_anchor <- function(info, rotate, anchor){
   expect_match(rotated["transform", ], paste0("rotate(", rotate), fixed=TRUE)
   # http://stackoverflow.com/questions/442404/retrieve-the-position-x-y-of-an-html-element
   
-  if (remDr$browserName=='chromote'){
-    tick_box_script <- 'document.getElementsByClassName("xaxis")[0].getBoundingClientRect().bottom;'
-    title_box_script <- 'document.getElementsByClassName("xtitle")[0].getBoundingClientRect().top;'
+  
+  tick_box_script <- 'document.getElementsByClassName("xaxis")[0].getBoundingClientRect().bottom;'
+  title_box_script <- 'document.getElementsByClassName("xtitle")[0].getBoundingClientRect().top;'
     
-    # Evaluate scripts and get the values
-    tick_box <- remDr$Runtime$evaluate(tick_box_script, returnByValue = TRUE)$result$value
-    title_box <- remDr$Runtime$evaluate(title_box_script, returnByValue = TRUE)$result$value
-    #An offset of 2.5 is added because chromote aligns text with slight differences
-    expect_true(title_box+2.5>= tick_box)
-  }
-  else{
-    tick_box <- remDr$executeScript(' return document.getElementsByClassName("xaxis")[0].firstChild.getBoundingClientRect()')
-    title_box <- remDr$executeScript('return document.getElementsByClassName("xtitle")[0].getBoundingClientRect()')
-    expect_true(title_box$top >= tick_box$bottom)
-    
-  }
+  # Evaluate scripts and get the values
+  tick_box <- remDr$Runtime$evaluate(tick_box_script, returnByValue = TRUE)$result$value
+  title_box <- remDr$Runtime$evaluate(title_box_script, returnByValue = TRUE)$result$value
+  #An offset of 2.5 is added because chromote aligns text with slight differences
+  expect_true(title_box+2.5>= tick_box)
+  
+
   
   
 

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -68,7 +68,6 @@ test_that('and hjust=1 means style="text-anchor: end;"', {
          not=sg)
   info <- animint2HTML(map)
   expect_rotate_anchor(info, "-70", "end")
-  
 })
 
 test_that('and hjust=0 means style="text-anchor: start;"', {

--- a/tests/testthat/test-renderer1-axis-angle-rotate.R
+++ b/tests/testthat/test-renderer1-axis-angle-rotate.R
@@ -50,7 +50,6 @@ test_that('axis.text.x=element_text(angle=90) means transform="rotate(-90)"', {
          not=sg)
   info <- animint2HTML(map)
   expect_rotate_anchor(info, "-90", "end")
-  
 })
 
 test_that('axis.text.x=element_text(angle=70) means transform="rotate(-70)"', {
@@ -59,7 +58,6 @@ test_that('axis.text.x=element_text(angle=70) means transform="rotate(-70)"', {
          not=sg)
   info <- animint2HTML(map)
   expect_rotate_anchor(info, "-70", "end")
-  
 })
 
 test_that('and hjust=1 means style="text-anchor: end;"', {

--- a/tests/testthat/test-renderer1-facet-lines.R
+++ b/tests/testthat/test-renderer1-facet-lines.R
@@ -46,12 +46,8 @@ wb.facets <-
        first=list(year=1975, country=c("United States", "Vietnam")),
        selector.types=list(country="multiple"),
        title="World Bank data (multiple selection, facets)")
-custom_delay <- function(milliseconds) {
-  Sys.sleep(milliseconds / 1000)
-}
 
-custom_delay(60) 
-
+Sys.sleep(60 / 1000)
 info <- animint2HTML(wb.facets)
 
 test_that("if group is in nest_order, it is last", {

--- a/tests/testthat/test-renderer1-facet-lines.R
+++ b/tests/testthat/test-renderer1-facet-lines.R
@@ -50,13 +50,7 @@ custom_delay <- function(milliseconds) {
   Sys.sleep(milliseconds / 1000)
 }
 
-# Check browser type and set delay or timeout accordingly
-if (remDr$browserName == "chromote") {
-  custom_delay(60) 
-} else {
-  remDr$setTimeout(milliseconds = 60 * 1000 * 2)
-
-}
+custom_delay(60) 
 
 info <- animint2HTML(wb.facets)
 

--- a/tests/testthat/test-renderer1-facet-lines.R
+++ b/tests/testthat/test-renderer1-facet-lines.R
@@ -47,7 +47,7 @@ wb.facets <-
        selector.types=list(country="multiple"),
        title="World Bank data (multiple selection, facets)")
 
-Sys.sleep(60 / 1000)
+remDr$default_timeout <- 1
 info <- animint2HTML(wb.facets)
 
 test_that("if group is in nest_order, it is last", {

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -14,10 +14,7 @@ for(var b in window) {
 myArray;'
 
 getVariables <- function(){
-    
-    vars <- remDr$Runtime$evaluate(myScript,returnByValue = TRUE)$result$value
-    
-  
+  vars <- remDr$Runtime$evaluate(myScript,returnByValue = TRUE)$result$value
   # ignore the "plot" variable -- 
   # https://github.com/tdhock/animint/pull/62#issuecomment-100008532
   # also ignore jQuery1238915281937 variable:
@@ -28,23 +25,16 @@ getVariables <- function(){
 test_that("animint.js only defines 1 object, called animint", {
   info <- animint2HTML(viz)
   animint.vars <- getVariables()
-  
   index.file <- file.path("animint-htmltest", "index.html")
-  
   html.lines <- readLines(index.file)
-  
   html.without <- html.lines[!grepl("animint.js", html.lines)]
-  
   cat(html.without, file=index.file, sep="\n")
   # Note: It's OK for the webdriver to spit out 
   # ReferenceError: Can't find variable: animint
   # since we've removed the animint.js script
-   
   remDr$refresh()
   Sys.sleep(3)
   without.vars <- getVariables()
-  
   diff.vars <- animint.vars[!animint.vars %in% without.vars]
-
   expect_identical(diff.vars, "animint")
 })

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -14,7 +14,7 @@ myArray;'
 
 getVariables <- function(){
   
-  vars<-runtime_evaluate(script=myScript, return.value=TRUE)
+  vars<-runtime_evaluate(script=myScript)
   
   # ignore the "plot" variable -- 
   # https://github.com/tdhock/animint/pull/62#issuecomment-100008532

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -6,7 +6,6 @@ viz <- list(scatter=ggplot()+
                          showSelected="Species",
                          data=iris))
 
-
 myScript <- 'myArray = [];
 for(var b in window) { 
   if(window.hasOwnProperty(b)) {myArray.push(b);} 
@@ -21,7 +20,6 @@ getVariables <- function(){
   grep("plot|jQuery", vars, value=TRUE, invert=TRUE)
 }
 
-    
 test_that("animint.js only defines 1 object, called animint", {
   info <- animint2HTML(viz)
   animint.vars <- getVariables()

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -13,7 +13,7 @@ for(var b in window) {
 myArray;'
 
 getVariables <- function(){
-  vars <- remDr$Runtime$evaluate(myScript,returnByValue = TRUE)$result$value
+  vars<-runtime_evaluate(script=myScript,return.value=TRUE)
   # ignore the "plot" variable -- 
   # https://github.com/tdhock/animint/pull/62#issuecomment-100008532
   # also ignore jQuery1238915281937 variable:

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -13,7 +13,9 @@ for(var b in window) {
 myArray;'
 
 getVariables <- function(){
-  vars<-runtime_evaluate(script=myScript,return.value=TRUE)
+  
+  vars<-runtime_evaluate(script=myScript, return.value=TRUE)
+  
   # ignore the "plot" variable -- 
   # https://github.com/tdhock/animint/pull/62#issuecomment-100008532
   # also ignore jQuery1238915281937 variable:

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -13,9 +13,7 @@ for(var b in window) {
 myArray;'
 
 getVariables <- function(){
-  
-  vars<-runtime_evaluate(script=myScript)
-  
+  vars <- runtime_evaluate(script=myScript)
   # ignore the "plot" variable -- 
   # https://github.com/tdhock/animint/pull/62#issuecomment-100008532
   # also ignore jQuery1238915281937 variable:

--- a/tests/testthat/test-renderer1-global-variables.R
+++ b/tests/testthat/test-renderer1-global-variables.R
@@ -6,26 +6,18 @@ viz <- list(scatter=ggplot()+
                          showSelected="Species",
                          data=iris))
 
-myScript <- 'myArray = [];
-for(var b in window) { 
-  if(window.hasOwnProperty(b)) {myArray.push(b);} 
-}
-return myArray;'
 
-myScript2 <- 'myArray = [];
+myScript <- 'myArray = [];
 for(var b in window) { 
   if(window.hasOwnProperty(b)) {myArray.push(b);} 
 }
 myArray;'
 
 getVariables <- function(){
-  if (remDr$browserName=="chromote"){
     
-    vars <- remDr$Runtime$evaluate(myScript2,returnByValue = TRUE)$result$value
+    vars <- remDr$Runtime$evaluate(myScript,returnByValue = TRUE)$result$value
     
-  } else {
-    vars <- remDr$executeScript(myScript)
-  }  
+  
   # ignore the "plot" variable -- 
   # https://github.com/tdhock/animint/pull/62#issuecomment-100008532
   # also ignore jQuery1238915281937 variable:

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -84,7 +84,7 @@ get_elements <- function(id){
   legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
   legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   
-  list(a178=top_widget_show_hide,
+  list(a172=top_widget_show_hide,
        b934=bottom_widget_show_hide,
        show_hide=legend_show_hide,
        widget=legend_widget)
@@ -98,7 +98,7 @@ plot1bottom <- get_elements("plot1bottom")
 test_that("clicking top legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1top_q_label_variable_a178")
+  clickID("plot1top_q_label_variable_a172")
   expect_equal(get_circles(), list(5, 10))
   
   clickID("plot1top_q_label_variable_b934")
@@ -107,14 +107,14 @@ test_that("clicking top legend adds/remove points", {
   clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_a178")
+  clickID("plot1top_q_label_variable_a172")
   expect_equal(get_circles(), list(10, 10))
 })
 
 test_that("clicking bottom legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1bottom_q_label_variable_a178")
+  clickID("plot1bottom_q_label_variable_a172")
   expect_equal(get_circles(), list(10, 5))
   
   clickID("plot1bottom_q_label_variable_b934")
@@ -123,7 +123,7 @@ test_that("clicking bottom legend adds/remove points", {
   clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_a178")
+  clickID("plot1bottom_q_label_variable_a172")
   expect_equal(get_circles(), list(10, 10))
 })
 clickSide<- function(position=NULL){

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -2,17 +2,9 @@ acontext("knitting multiple animint plots in a single Rmd")
 print("In test")
 knitr::knit_meta() #clear knitr 'metadata'
 # Rmd.file <- "~/R/animint/inst/examples/test_knit_print.Rmd" ## Do we need this???
-Rmd.file <- system.file("inst", "examples", "test_knit_print.Rmd", 
-                         package = "animint2")
-Rmd.file <- file.path("..", "..", "inst","examples", "test_knit_print.Rmd")
+Rmd.file <- system.file("examples", "test_knit_print.Rmd", 
+                        package = "animint2")
 index.file <- file.path("animint-htmltest", "index.Rmd")
-
-if (!dir.exists(dirname(index.file))) {
-  dir.create(dirname(index.file), recursive = TRUE)
-}
-if (!file.exists(index.file)) {
-  file.create(index.file)
-}
 
 file.copy(Rmd.file, index.file, overwrite=TRUE)
 ## https://github.com/rstudio/rmarkdown/issues/587#issuecomment-168437646
@@ -136,11 +128,11 @@ test_that("clicking bottom legend adds/remove points", {
 })
 clickSide<- function(position=NULL){
   if(position=="top"){
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));",position))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));",position))
-  }else if(position=="bottom"){
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));",position))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));",position))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+  }else{
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
   }
 }
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -79,15 +79,15 @@ get_circles <- function(html=getHTML()) {
 
 get_elements <- function(id){
   
-  a<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
-  b<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
-  show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
-  widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
+  top_widget_show_hide<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
+  bottom_widget_show_hide<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
+  legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
+  legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   
-  list(a178=a,
-       b934=b,
-       show_hide=show_hide,
-       widget=widget)
+  list(a178=top_widget_show_hide,
+       b934=bottom_widget_show_hide,
+       show_hide=legend_show_hide,
+       widget=legend_widget)
 }
 
 plot1top <- get_elements("plot1top")

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -84,8 +84,8 @@ get_elements <- function(id){
   legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
   legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   
-  list(top_widget_show_hide=top_widget_show_hide,
-       bottom_widget_show_hide=bottom_widget_show_hide,
+  list(a178=top_widget_show_hide,
+       b934=bottom_widget_show_hide,
        show_hide=legend_show_hide,
        widget=legend_widget)
 }
@@ -98,32 +98,32 @@ plot1bottom <- get_elements("plot1bottom")
 test_that("clicking top legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1top_q_label_variable_top_widget_show_hide")
+  clickID("plot1top_q_label_variable_a178")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_bottom_widget_show_hide")
+  clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(0, 10))
   
-  clickID("plot1top_q_label_variable_bottom_widget_show_hide")
+  clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_top_widget_show_hide")
+  clickID("plot1top_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
 
 test_that("clicking bottom legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1bottom_q_label_variable_top_widget_show_hide")
+  clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_bottom_widget_show_hide")
+  clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 0))
   
-  clickID("plot1bottom_q_label_variable_bottom_widget_show_hide")
+  clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_top_widget_show_hide")
+  clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
 clickSide<- function(position=NULL){

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -79,15 +79,10 @@ get_circles <- function(html=getHTML()) {
 
 get_elements <- function(id){
   
-  top_widget_show_hide<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
-  bottom_widget_show_hide<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
-  legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
-  legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
-  
-  list(a178=top_widget_show_hide,
-       b934=bottom_widget_show_hide,
-       show_hide=legend_show_hide,
-       widget=legend_widget)
+  list(a178=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE),
+       b934=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE),
+       show_hide=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE),
+       widget=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE))
 }
 
 plot1top <- get_elements("plot1top")

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -206,9 +206,9 @@ test_that("top widget adds/remove points", {
   expect_equal(get_circles(), list(5, 10))
   sendBackspace()
   expect_equal(get_circles(), list(0, 10))
-  sendA()
+  send("a")
   expect_equal(get_circles(), list(5, 10))
-  sendB()
+  send("b")
   expect_equal(get_circles(), list(10, 10))
 })
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -78,11 +78,10 @@ get_circles <- function(html=getHTML()) {
 }
 
 get_elements <- function(id){
-  
-  list(a178=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0),
-       b934=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=1),
-       show_hide=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0),
-       widget=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1))
+  list(a178=runtime_evaluate_helper(id=id, class_name='show_hide_selector_widgets', list_num=0),
+       b934=runtime_evaluate_helper(id=id, class_name='show_hide_selector_widgets', list_num=1),
+       show_hide=runtime_evaluate_helper(id=id, class_name='table.legend tr.label_variable', list_num=0),
+       widget=runtime_evaluate_helper(id=id, class_name='table.legend tr.label_variable', list_num=1))
 }
 
 plot1top <- get_elements("plot1top")
@@ -121,24 +120,20 @@ test_that("clicking bottom legend adds/remove points", {
   clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
-clickSide<- function(position=NULL){
-  if(position=="top"){
-    runtime_evaluate_helper(id=as.character("plot1top"),class_name='show_hide_selector_widgets',list_num=0,dispatch_event=TRUE)
-    runtime_evaluate_helper(id=as.character("plot1top"),class_name='selectize-input',list_num=0,dispatch_event=TRUE)
-  }else if(position=="bottom"){
-    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='show_hide_selector_widgets',list_num=0,dispatch_event=TRUE)
-    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='selectize-input',list_num=0,dispatch_event=TRUE)
-  }
+clickSide <- function(position=NULL){
+  id <- paste0("plot1", position)
+  runtime_evaluate_helper(id=id, class_name='show_hide_selector_widgets', list_num=0, dispatch_event=TRUE)
+  runtime_evaluate_helper(id=id, class_name='selectize-input', list_num=0, dispatch_event=TRUE)
 }
 
 sendBackspace <- function() {
-  sendKey("Backspace", "Backspace", 8)
+  sendKey("Backspace")
   Sys.sleep(0.5)
 }
 
 send <- function(alphabet) {
   remDr$Input$insertText(text = alphabet)
-  sendKey("Enter", "Enter", 13)
+  sendKey("Enter")
   Sys.sleep(0.5)
 }
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -136,11 +136,11 @@ test_that("clicking bottom legend adds/remove points", {
 })
 clickSide<- function(position=NULL){
   if(position=="top"){
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-  }else{
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));",position))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));",position))
+  }else if(position=="bottom"){
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));",position))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('plot1%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));",position))
   }
 }
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -1,5 +1,4 @@
 acontext("knitting multiple animint plots in a single Rmd")
-print("In test")
 knitr::knit_meta() #clear knitr 'metadata'
 # Rmd.file <- "~/R/animint/inst/examples/test_knit_print.Rmd" ## Do we need this???
 Rmd.file <- system.file("examples", "test_knit_print.Rmd", 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -78,10 +78,10 @@ get_circles <- function(html=getHTML()) {
 }
 
 get_elements <- function(id){
-  a<- runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),return.value=TRUE)
-  b<- runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),return.value=TRUE)
-  show_hide <- runtime_evaluate(script =sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[0]", as.character(id)), return.value=TRUE)
-  widget <-runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[1]", as.character(id)),return.value=TRUE)
+  a<- runtime_evaluate_helper(id=as.character(id),class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
+  b<- runtime_evaluate_helper(id=as.character(id),class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
+  show_hide <- runtime_evaluate_helper(id=as.character(id),class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
+  widget <- runtime_evaluate_helper(id=as.character(id),class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   list(a178=a,
        b934=b,
        show_hide=show_hide,
@@ -126,11 +126,11 @@ test_that("clicking bottom legend adds/remove points", {
 })
 clickSide<- function(position=NULL){
   if(position=="top"){
-    runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-    runtime_evaluate(script=sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+    runtime_evaluate_helper(id=as.character("plot1top"),class_name='show_hide_selector_widgets',list_num=0)
+    runtime_evaluate_helper(id=as.character("plot1top"),class_name='selectize-input',list_num=0)
   }else{
-    runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-    runtime_evaluate(script=sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='show_hide_selector_widgets',list_num=0)
+    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='selectize-input',list_num=0)
   }
 }
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -84,7 +84,7 @@ get_elements <- function(id){
   legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
   legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   
-  list(a172=top_widget_show_hide,
+  list(a1721=top_widget_show_hide,
        b934=bottom_widget_show_hide,
        show_hide=legend_show_hide,
        widget=legend_widget)
@@ -98,7 +98,7 @@ plot1bottom <- get_elements("plot1bottom")
 test_that("clicking top legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1top_q_label_variable_a172")
+  clickID("plot1top_q_label_variable_a1721")
   expect_equal(get_circles(), list(5, 10))
   
   clickID("plot1top_q_label_variable_b934")
@@ -107,14 +107,14 @@ test_that("clicking top legend adds/remove points", {
   clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_a172")
+  clickID("plot1top_q_label_variable_a1721")
   expect_equal(get_circles(), list(10, 10))
 })
 
 test_that("clicking bottom legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1bottom_q_label_variable_a172")
+  clickID("plot1bottom_q_label_variable_a1721")
   expect_equal(get_circles(), list(10, 5))
   
   clickID("plot1bottom_q_label_variable_b934")
@@ -123,7 +123,7 @@ test_that("clicking bottom legend adds/remove points", {
   clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_a172")
+  clickID("plot1bottom_q_label_variable_a1721")
   expect_equal(get_circles(), list(10, 10))
 })
 clickSide<- function(position=NULL){

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -8,11 +8,9 @@ Rmd.file <- file.path("..", "..", "inst","examples", "test_knit_print.Rmd")
 index.file <- file.path("animint-htmltest", "index.Rmd")
 
 if (!dir.exists(dirname(index.file))) {
-  # Create directory if it doesn't exist
   dir.create(dirname(index.file), recursive = TRUE)
 }
 if (!file.exists(index.file)) {
-  # Create index.file if it doesn't exist
   file.create(index.file)
 }
 
@@ -94,8 +92,6 @@ get_elements <- function(id){
   b <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
   show_hide <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[0]", as.character(id)),returnByValue = TRUE)$result$value
   widget <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[1]", as.character(id)),returnByValue = TRUE)$result$value
-    
-  
   list(a178=a,
        b934=b,
        show_hide=show_hide,
@@ -138,39 +134,28 @@ test_that("clicking bottom legend adds/remove points", {
   clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
-
-clickTop <- function() {
-  remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-  remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-
-}
-
-clickBottom <- function() {
-  remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-  remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-  
-}
-
-# Function to send a key event
-sendKey <- function(key, code, keyCode) {
-  remDr$Input$dispatchKeyEvent(type = "keyDown", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
-  remDr$Input$dispatchKeyEvent(type = "keyUp", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
+clickSide<- function(position=NULL){
+  if(position=="top"){
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+  }else{
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+  }
 }
 
 sendBackspace <- function() {
   sendKey("Backspace", "Backspace", 8)
-  
   Sys.sleep(0.5)
 }
 
 send <- function(alphabet) {
   remDr$Input$insertText(text = alphabet)
   sendKey("Enter", "Enter", 13)
-  
   Sys.sleep(0.5)
 }
 
-clickTop()
+clickSide("top")
 test_that("top widget adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   sendBackspace()
@@ -183,7 +168,7 @@ test_that("top widget adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
 })
 
-clickBottom()
+clickSide("bottom")
 test_that("bottom widget adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   sendBackspace()

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -126,11 +126,11 @@ test_that("clicking bottom legend adds/remove points", {
 })
 clickSide<- function(position=NULL){
   if(position=="top"){
-    runtime_evaluate_helper(id=as.character("plot1top"),class_name='show_hide_selector_widgets',list_num=0)
-    runtime_evaluate_helper(id=as.character("plot1top"),class_name='selectize-input',list_num=0)
-  }else{
-    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='show_hide_selector_widgets',list_num=0)
-    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='selectize-input',list_num=0)
+    runtime_evaluate_helper(id=as.character("plot1top"),class_name='show_hide_selector_widgets',list_num=0,dispatch_event=TRUE)
+    runtime_evaluate_helper(id=as.character("plot1top"),class_name='selectize-input',list_num=0,dispatch_event=TRUE)
+  }else if(position=="bottom"){
+    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='show_hide_selector_widgets',list_num=0,dispatch_event=TRUE)
+    runtime_evaluate_helper(id=as.character("plot1bottom"),class_name='selectize-input',list_num=0,dispatch_event=TRUE)
   }
 }
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -78,11 +78,10 @@ get_circles <- function(html=getHTML()) {
 }
 
 get_elements <- function(id){
-  ##print("before div")
-  a <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
-  b <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
-  show_hide <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[0]", as.character(id)),returnByValue = TRUE)$result$value
-  widget <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[1]", as.character(id)),returnByValue = TRUE)$result$value
+  a<- runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),return.value=TRUE)
+  b<- runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),return.value=TRUE)
+  show_hide <- runtime_evaluate(script =sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[0]", as.character(id)), return.value=TRUE)
+  widget <-runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[1]", as.character(id)),return.value=TRUE)
   list(a178=a,
        b934=b,
        show_hide=show_hide,
@@ -127,11 +126,11 @@ test_that("clicking bottom legend adds/remove points", {
 })
 clickSide<- function(position=NULL){
   if(position=="top"){
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+    runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
+    runtime_evaluate(script=sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
   }else{
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+    runtime_evaluate(script=sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+    runtime_evaluate(script=sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
   }
 }
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -79,10 +79,10 @@ get_circles <- function(html=getHTML()) {
 
 get_elements <- function(id){
   
-  list(a178=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE),
-       b934=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE),
-       show_hide=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE),
-       widget=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE))
+  list(a178=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0),
+       b934=runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=1),
+       show_hide=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0),
+       widget=runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1))
 }
 
 plot1top <- get_elements("plot1top")

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -84,7 +84,7 @@ get_elements <- function(id){
   legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
   legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   
-  list(a1721=top_widget_show_hide,
+  list(a178=top_widget_show_hide,
        b934=bottom_widget_show_hide,
        show_hide=legend_show_hide,
        widget=legend_widget)
@@ -98,7 +98,7 @@ plot1bottom <- get_elements("plot1bottom")
 test_that("clicking top legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1top_q_label_variable_a1721")
+  clickID("plot1top_q_label_variable_a178")
   expect_equal(get_circles(), list(5, 10))
   
   clickID("plot1top_q_label_variable_b934")
@@ -107,14 +107,14 @@ test_that("clicking top legend adds/remove points", {
   clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_a1721")
+  clickID("plot1top_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
 
 test_that("clicking bottom legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1bottom_q_label_variable_a1721")
+  clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 5))
   
   clickID("plot1bottom_q_label_variable_b934")
@@ -123,7 +123,7 @@ test_that("clicking bottom legend adds/remove points", {
   clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_a1721")
+  clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
 clickSide<- function(position=NULL){

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -78,10 +78,12 @@ get_circles <- function(html=getHTML()) {
 }
 
 get_elements <- function(id){
+  
   a<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
   b<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
   show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
   widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
+  
   list(a178=a,
        b934=b,
        show_hide=show_hide,

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -84,8 +84,8 @@ get_elements <- function(id){
   legend_show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
   legend_widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   
-  list(a178=top_widget_show_hide,
-       b934=bottom_widget_show_hide,
+  list(top_widget_show_hide=top_widget_show_hide,
+       bottom_widget_show_hide=bottom_widget_show_hide,
        show_hide=legend_show_hide,
        widget=legend_widget)
 }
@@ -98,32 +98,32 @@ plot1bottom <- get_elements("plot1bottom")
 test_that("clicking top legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1top_q_label_variable_a178")
+  clickID("plot1top_q_label_variable_top_widget_show_hide")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_b934")
+  clickID("plot1top_q_label_variable_bottom_widget_show_hide")
   expect_equal(get_circles(), list(0, 10))
   
-  clickID("plot1top_q_label_variable_b934")
+  clickID("plot1top_q_label_variable_bottom_widget_show_hide")
   expect_equal(get_circles(), list(5, 10))
   
-  clickID("plot1top_q_label_variable_a178")
+  clickID("plot1top_q_label_variable_top_widget_show_hide")
   expect_equal(get_circles(), list(10, 10))
 })
 
 test_that("clicking bottom legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
   
-  clickID("plot1bottom_q_label_variable_a178")
+  clickID("plot1bottom_q_label_variable_top_widget_show_hide")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_b934")
+  clickID("plot1bottom_q_label_variable_bottom_widget_show_hide")
   expect_equal(get_circles(), list(10, 0))
   
-  clickID("plot1bottom_q_label_variable_b934")
+  clickID("plot1bottom_q_label_variable_bottom_widget_show_hide")
   expect_equal(get_circles(), list(10, 5))
   
-  clickID("plot1bottom_q_label_variable_a178")
+  clickID("plot1bottom_q_label_variable_top_widget_show_hide")
   expect_equal(get_circles(), list(10, 10))
 })
 clickSide<- function(position=NULL){

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -78,10 +78,10 @@ get_circles <- function(html=getHTML()) {
 }
 
 get_elements <- function(id){
-  a<- runtime_evaluate_helper(id=as.character(id),class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
-  b<- runtime_evaluate_helper(id=as.character(id),class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
-  show_hide <- runtime_evaluate_helper(id=as.character(id),class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
-  widget <- runtime_evaluate_helper(id=as.character(id),class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
+  a<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
+  b<- runtime_evaluate_helper(id=id,class_name='show_hide_selector_widgets',list_num=0,return.value=TRUE)
+  show_hide <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=0,return.value=TRUE)
+  widget <- runtime_evaluate_helper(id=id,class_name='table.legend tr.label_variable',list_num=1,return.value=TRUE)
   list(a178=a,
        b934=b,
        show_hide=show_hide,

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -90,25 +90,12 @@ get_circles <- function(html=getHTML()) {
 
 get_elements <- function(id){
   ##print("before div")
-  if (remDr$browserName == "chromote") {
-    a <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
-    b <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
-    show_hide <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[0]", as.character(id)),returnByValue = TRUE)$result$value
-    widget <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[1]", as.character(id)),returnByValue = TRUE)$result$value
+  a <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
+  b <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0]", as.character(id)),returnByValue = TRUE)$result$value
+  show_hide <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[0]", as.character(id)),returnByValue = TRUE)$result$value
+  widget <- remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('table.legend tr.label_variable')[1]", as.character(id)),returnByValue = TRUE)$result$value
     
-  } else {
-    div <- remDr$findElement("id", id)
-    ## For debugging a NoSuchElement error I insert print statements.
-    ##print("before css selector")
-    tr.list <- div$findChildElements(
-      "css selector", "table.legend tr.label_variable")
-    a <- tr.list[[1]]
-    b <- tr.list[[2]]
-    ##print("before show_hide")
-    show_hide <- div$findChildElement("class name", "show_hide_selector_widgets")
-    ##print("before col_selector_widget")
-    widget <- div$findChildElement("class name", "label_variable_selector_widget")
-  }
+  
   list(a178=a,
        b934=b,
        show_hide=show_hide,
@@ -153,25 +140,15 @@ test_that("clicking bottom legend adds/remove points", {
 })
 
 clickTop <- function() {
-if (remDr$browserName == "chromote") {
   remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
   remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1top")))
-} else { 
-  plot1top$show_hide$clickElement()
-  s.div <- plot1top$widget$findChildElement("class name", "selectize-input")
-  s.div$clickElement()
-}
+
 }
 
 clickBottom <- function() {
-  if (remDr$browserName == "chromote") {
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-    remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
-  } else { 
-    plot1top$show_hide$clickElement()
-    s.div <- plot1top$widget$findChildElement("class name", "selectize-input")
-    s.div$clickElement()
-  }
+  remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s');div.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+  remDr$Runtime$evaluate(sprintf("div = document.getElementById('%s'); div.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));", as.character("plot1bottom")))
+  
 }
 
 # Function to send a key event
@@ -181,21 +158,15 @@ sendKey <- function(key, code, keyCode) {
 }
 
 sendBackspace <- function() {
-  if (remDr$browserName == "chromote") {
-    sendKey("Backspace", "Backspace", 8)
-  } else {
-    remDr$sendKeysToActiveElement(list(key="backspace"))
-  }
+  sendKey("Backspace", "Backspace", 8)
+  
   Sys.sleep(0.5)
 }
 
 send <- function(alphabet) {
-  if (remDr$browserName == "chromote") {
-    remDr$Input$insertText(text = alphabet)
-    sendKey("Enter", "Enter", 13)
-  } else {
-    remDr$sendKeysToActiveElement(list(alphabet, key="enter"))
-  }
+  remDr$Input$insertText(text = alphabet)
+  sendKey("Enter", "Enter", 13)
+  
   Sys.sleep(0.5)
 }
 

--- a/tests/testthat/test-renderer1-url-fragment.R
+++ b/tests/testthat/test-renderer1-url-fragment.R
@@ -32,7 +32,7 @@ test_that("one observation selected for url with no selection", {
   expect_equal(as.numeric(opacity.str[!is.selected]), rep(0.5, 298))
 })
 
-old_address <- runtime_evaluate(script="window.location.href",return.value=TRUE)
+old_address <- runtime_evaluate(script="window.location.href")
 new_address <- paste0(old_address, '#Species={setosa}')
 remDr$navigate(new_address)
 remDr$refresh()

--- a/tests/testthat/test-renderer1-url-fragment.R
+++ b/tests/testthat/test-renderer1-url-fragment.R
@@ -32,7 +32,7 @@ test_that("one observation selected for url with no selection", {
   expect_equal(as.numeric(opacity.str[!is.selected]), rep(0.5, 298))
 })
 
-old_address <- remDr$Runtime$evaluate("window.location.href")$result$value
+old_address <- runtime_evaluate(script="window.location.href",return.value=TRUE)
 new_address <- paste0(old_address, '#Species={setosa}')
 remDr$navigate(new_address)
 remDr$refresh()

--- a/tests/testthat/test-renderer1-url-fragment.R
+++ b/tests/testthat/test-renderer1-url-fragment.R
@@ -14,7 +14,6 @@ viz <- list(
 
 info <- animint2HTML(viz)
 
-
 test_that("all species are selected for url with no selection", {
   opacity.str <- getStyleValue(info$html, "//td[@class='legend_entry_label']", "opacity")
   opacity.num <- as.numeric(opacity.str)
@@ -34,11 +33,7 @@ test_that("one observation selected for url with no selection", {
 })
 
 old_address <- remDr$Runtime$evaluate("window.location.href")$result$value
- 
-
-
 new_address <- paste0(old_address, '#Species={setosa}')
-
 remDr$navigate(new_address)
 remDr$refresh()
 Sys.sleep(10)
@@ -63,4 +58,3 @@ test_that("one species is selected for url with selection", {
 ## })
 
 remDr$navigate(old_address)
-

--- a/tests/testthat/test-renderer1-url-fragment.R
+++ b/tests/testthat/test-renderer1-url-fragment.R
@@ -33,12 +33,8 @@ test_that("one observation selected for url with no selection", {
   expect_equal(as.numeric(opacity.str[!is.selected]), rep(0.5, 298))
 })
 
-if (remDr$browserName == "chromote") {
-  old_address <- remDr$Runtime$evaluate("window.location.href")$result$value
-} else {
-
-  old_address <- remDr$getCurrentUrl()[[1]]
-}
+old_address <- remDr$Runtime$evaluate("window.location.href")$result$value
+ 
 
 
 new_address <- paste0(old_address, '#Species={setosa}')

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -43,17 +43,13 @@ getBounds <- function(geom.class){
 
 test_that("bottom of widerect is above line", {
   
-  if (remDr$browserName=="chromote"){
-    rect_bound_script <- 'document.getElementsByClassName("geom1_widerect_gg")[0].getBoundingClientRect().bottom;'
-    rect_bound <- remDr$Runtime$evaluate(rect_bound_script,returnByValue = TRUE)$result$value
-    line_bound_script <- 'document.getElementsByClassName("geom2_line_gg")[0].getBoundingClientRect().top;'
-    line_bound <- remDr$Runtime$evaluate(line_bound_script,returnByValue = TRUE)$result$value
-    expect_lt(rect_bound, line_bound)
-  } else {
-    rect.bounds <- getBounds("geom1_widerect_gg")
-    line.bounds <- getBounds("geom2_line_gg")
-    expect_lt(rect.bounds$bottom, line.bounds$top)
-  }
+  
+  rect_bound_script <- 'document.getElementsByClassName("geom1_widerect_gg")[0].getBoundingClientRect().bottom;'
+  rect_bound <- remDr$Runtime$evaluate(rect_bound_script,returnByValue = TRUE)$result$value
+  line_bound_script <- 'document.getElementsByClassName("geom2_line_gg")[0].getBoundingClientRect().top;'
+  line_bound <- remDr$Runtime$evaluate(line_bound_script,returnByValue = TRUE)$result$value
+  expect_lt(rect_bound, line_bound)
+  
   
 })
 
@@ -339,14 +335,9 @@ test_that("clicking legend removes/adds countries", {
   expect_equal(sum(twoclicks$legends=="1"), 14)
   expect_equal(sum(twoclicks$legends=="0.5"), 0)
 })
-if (remDr$browserName=="chromote"){
-  clickID('updates_ms')
-} else {
-  e <- remDr$findElement("id", "updates_ms")
-  e$clickElement()
-  e$clearElement()
-  e$sendKeysToElement(list("3000", key="enter"))
-}
+
+clickID('updates_ms')
+ 
 
 
 test_that("pause stops animation (third time)", {
@@ -363,29 +354,16 @@ sendKey <- function(key, code, keyCode) {
   remDr$Input$dispatchKeyEvent(type = "keyUp", key = key, code = code, windowsVirtualKeyCode = keyCode, nativeVirtualKeyCode = keyCode)
 }
 
-if (remDr$browserName=="chromote"){
-  
-   remDr$Runtime$evaluate("document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
-   remDr$Runtime$evaluate("childDom = document.getElementsByClassName('year_variable_selector_widget')[0]; childDom.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));")
-   sendKey("Backspace", "Backspace", 8)
-   remDr$Input$insertText(text = "1962")
-   remDr$Runtime$evaluate("childDom = document.getElementsByClassName('year_variable_selector_widget')[0]; childDom.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));") 
-   sendKey("ArrowDown", "ArrowDown", 40)
-   sendKey("Enter", "Enter", 13)
+
+remDr$Runtime$evaluate("document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
+remDr$Runtime$evaluate("childDom = document.getElementsByClassName('year_variable_selector_widget')[0]; childDom.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));")
+sendKey("Backspace", "Backspace", 8)
+remDr$Input$insertText(text = "1962")
+remDr$Runtime$evaluate("childDom = document.getElementsByClassName('year_variable_selector_widget')[0]; childDom.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));") 
+sendKey("ArrowDown", "ArrowDown", 40)
+sendKey("Enter", "Enter", 13)
    
-} else {
-  e <- remDr$findElement("class name", "show_hide_selector_widgets")
-  e$clickElement()
-  s.tr <- remDr$findElement("class name", "year_variable_selector_widget")
-  s.div <- s.tr$findChildElement("class name", "selectize-input")
-  s.div$clickElement()
-# Selenium Versions > 2 do not support the sendKeysToActiveElement function as I found on their github.
-# https://github.com/SeleniumHQ/selenium/issues/7686
-# Looking to make it work with JavaScript or JQuery
-  remDr$sendKeysToActiveElement(list(key="backspace"))
-  remDr$sendKeysToActiveElement(list("1962"))
-  remDr$sendKeysToActiveElement(list(key="enter"))
-}
+ 
 Sys.sleep(3)
 
 test_that("typing into selectize widget changes year to 1962", {
@@ -393,21 +371,8 @@ test_that("typing into selectize widget changes year to 1962", {
   expect_identical(current.year, "1962")
 })
 
-## Down arrow goes to the first element in the drop down list on chromote
-## Skipping the test on chromote since behavior of down arrow key is 
-## different on firefox and chromote
-if (remDr$browserName!="chromote"){
- 
-  s.div$clickElement()
-  remDr$sendKeysToActiveElement(list(key="down_arrow"))
-  remDr$sendKeysToActiveElement(list(key="enter"))
-  Sys.sleep(1)
 
-test_that("down arrow key changes year to 1963", {
-  current.year <- getYear()
-  expect_identical(current.year, "1963")
-})
-}
+
 
 getCountries <- function(){
   country.labels <- getNodeSet(getHTML(), '//g[@class="geom8_text_ts"]//text')
@@ -419,18 +384,11 @@ test_that("initial countries same as first", {
   expect_identical(sort(country.vec), sort(wb.facets$first$country))
 })
 
-if (remDr$browserName=="chromote"){
-  
-  remDr$Runtime$evaluate("childDom = document.getElementsByClassName('country_variable_selector_widget')[0]; childDom.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));")
-  remDr$Input$insertText(text = "Afg")
-  sendKey("Enter", "Enter", 13)
-} else {
-  s.tr <- remDr$findElement("class name", "country_variable_selector_widget")
-  s.div <- s.tr$findChildElement("class name", "selectize-input")
-  s.div$clickElement()
-  remDr$sendKeysToActiveElement(list("Afg"))
-  remDr$sendKeysToActiveElement(list(key="enter"))
-}
+
+remDr$Runtime$evaluate("childDom = document.getElementsByClassName('country_variable_selector_widget')[0]; childDom.getElementsByClassName('selectize-input')[0].dispatchEvent(new CustomEvent('click'));")
+remDr$Input$insertText(text = "Afg")
+sendKey("Enter", "Enter", 13)
+ 
 Sys.sleep(1)
 
 test_that("Afg autocompletes to Afghanistan", {
@@ -440,24 +398,7 @@ test_that("Afg autocompletes to Afghanistan", {
 })
 
 ## The below code is only reproducible on firefox
-if (remDr$browserName!="chromote"){ 
-  div.list <- s.tr$findChildElements("class name", "item")
-  names(div.list) <- sapply(div.list, function(e)e$getElementText()[[1]])
-  afg.div <- div.list[["Afghanistan"]]
-  # clickElement has some really weird behavior, repeating it several times 
-  # focuses different things and I can't reliably get it to actually focus on
-  # the US element that the test was before.
-  # This is kinda a hack that causes it to backspace the last element in the list
-  afg.div$clickElement()
-  remDr$sendKeysToActiveElement(list(key="backspace")) 
- Sys.sleep(1)
 
- test_that("backspace removes Afghanistan from selected countries", {
-   country.vec <- getCountries()
-   expected.countries <- c("United States", "Vietnam")
-   expect_identical(sort(country.vec), sort(expected.countries))
- })
-}
 getWidth <- function(){
   node.set <-
     getNodeSet(getHTML(), '//g[@class="geom10_bar_bar"]//rect[@id="Vietnam"]')
@@ -480,34 +421,8 @@ test_that("middle of transition != after when duration=2000", {
   expect_true(during.width != after.width)
 })
 
-if (remDr$browserName=="chromote") {
-  
-  remDr$Runtime$evaluate("document.getElementById('plot_duration_ms_year').value = 0;")
-  clickID("plot_duration_ms_year")
-  sendKey("Enter", "Enter", 13)
-  
-} else {
-  e <- remDr$findElement("id", "plot_duration_ms_year")
-  e$clickElement()
-  e$clearElement()
-  e$sendKeysToElement(list("0", key="enter"))
-}
-Sys.sleep(1)
 
-## For chromote, the test fails because transition still happens when duration=0
-if (remDr$browserName!="chromote") {
-test_that("middle of transition == after when duration=0", {
-  clickID("year1960")
-  Sys.sleep(1)
-  before.width <- getWidth()
-  clickID("year2010")
-  during.width <- getWidth()
-  Sys.sleep(0.1)
-  after.width <- getWidth()
-  rbind(before=before.width,
-        during=during.width,
-        after=after.width)
-  expect_true(before.width != after.width)
-  expect_true(during.width == after.width)
-})
-}
+remDr$Runtime$evaluate("document.getElementById('plot_duration_ms_year').value = 0;")
+clickID("plot_duration_ms_year")
+sendKey("Enter", "Enter", 13)
+

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -341,11 +341,11 @@ test_that("pause stops animation (third time)", {
 
 runtime_evaluate_helper(class_name="show_hide_selector_widgets",list_num=0,dispatch_event=TRUE)
 clickSelector("year_variable_selector_widget")
-sendKey("Backspace", "Backspace", 8)
+sendKey("Backspace")
 remDr$Input$insertText(text = "1962")
 clickSelector("year_variable_selector_widget")
-sendKey("ArrowDown", "ArrowDown", 40)
-sendKey("Enter", "Enter", 13)
+sendKey("ArrowDown")
+sendKey("Enter")
 Sys.sleep(3)
 
 test_that("typing into selectize widget changes year to 1962", {
@@ -365,7 +365,7 @@ test_that("initial countries same as first", {
 
 clickSelector("country_variable_selector_widget")
 remDr$Input$insertText(text = "Afg")
-sendKey("Enter", "Enter", 13)
+sendKey("Enter")
  
 Sys.sleep(1)
 
@@ -376,7 +376,7 @@ test_that("Afg autocompletes to Afghanistan", {
 })
 
 clickSelector("country_variable_selector_widget")
-sendKey("Backspace", "Backspace", 8)
+sendKey("Backspace")
 Sys.sleep(1)
 
 test_that("backspace removes Afghanistan from selected countries", {

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -339,7 +339,8 @@ test_that("pause stops animation (third time)", {
   expect_true(old.year == new.year)
 })
 
-runtime_evaluate(script="document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
+#runtime_evaluate(script="document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
+runtime_evaluate_helper(class_name="show_hide_selector_widgets",list_num=0,dispatch_event=TRUE)
 clickSelector("year_variable_selector_widget")
 sendKey("Backspace", "Backspace", 8)
 remDr$Input$insertText(text = "1962")

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -43,13 +43,8 @@ clickSelector <- function(selectorName) {
 
 getBounds <- function(geom.class, position){
     
-    if(position == "top") {
-      script.txt <- sprintf('document.getElementsByClassName("%s")[0].getBoundingClientRect().top', geom.class)
-      remDr$Runtime$evaluate(script.txt,returnByValue = TRUE)$result$value
-    } else {
-      script.txt <- sprintf('document.getElementsByClassName("%s")[0].getBoundingClientRect().bottom', geom.class)
-      remDr$Runtime$evaluate(script.txt,returnByValue = TRUE)$result$value
-    }
+  script.txt <- sprintf('document.getElementsByClassName("%s")[0].getBoundingClientRect().%s', geom.class, position)
+  remDr$Runtime$evaluate(script.txt,returnByValue = TRUE)$result$value
 }
 
 test_that("bottom of widerect is above line", {

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -35,22 +35,14 @@ viz <- animint(
 info <- animint2HTML(viz)
 expect_source(NULL)
 
-clickSelector <- function(selectorName) {
-  
+clickSelector <- function(selectorName) {  
   script.txt <- sprintf('childDom = document.getElementsByClassName("%s")[0]; childDom.getElementsByClassName("selectize-input")[0].dispatchEvent(new CustomEvent("click"));', selectorName)
   remDr$Runtime$evaluate(script.txt)
 }
 
-getBounds <- function(geom.class, position){
-    
-  script.txt <- sprintf('document.getElementsByClassName("%s")[0].getBoundingClientRect().%s', geom.class, position)
-  remDr$Runtime$evaluate(script.txt,returnByValue = TRUE)$result$value
-}
-
-test_that("bottom of widerect is above line", {
-  
-  rect_bound <- getBounds("geom1_widerect_gg", "bottom")
-  line_bound <- getBounds("geom2_line_gg", "top")
+test_that("bottom of widerect is above line", {  
+  rect_bound <- getClassBound("geom1_widerect_gg", "bottom")
+  line_bound <- getClassBound("geom2_line_gg", "top")
   expect_lt(rect_bound, line_bound)
 })
 

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -428,9 +428,7 @@ test_that("middle of transition != after when duration=2000", {
 })
 
 
-remDr$Runtime$evaluate("document.getElementById('plot_duration_ms_year').value = 0;")
-clickID("plot_duration_ms_year")
-sendKey("Enter", "Enter", 13)
+remDr$Runtime$evaluate("var e = document.getElementById('plot_duration_ms_year'); e.value = 0;e.dispatchEvent(new Event('change'));")
 Sys.sleep(1)
 
 test_that("middle of transition == after when duration=0", {
@@ -445,5 +443,5 @@ test_that("middle of transition == after when duration=0", {
         during=during.width,
         after=after.width)
   expect_true(before.width != after.width)
-  #expect_true(during.width == after.width)
+  expect_true(during.width == after.width)
 })

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -331,8 +331,6 @@ test_that("clicking legend removes/adds countries", {
 
 clickID('updates_ms')
  
-
-
 test_that("pause stops animation (third time)", {
   clickID("play_pause")
   old.year <- getYear()
@@ -349,16 +347,12 @@ clickSelector("year_variable_selector_widget")
 sendKey("ArrowDown", "ArrowDown", 40)
 sendKey("Enter", "Enter", 13)
    
- 
 Sys.sleep(3)
 
 test_that("typing into selectize widget changes year to 1962", {
   current.year <- getYear()
   expect_identical(current.year, "1962")
 })
-
-
-
 
 getCountries <- function(){
   country.labels <- getNodeSet(getHTML(), '//g[@class="geom8_text_ts"]//text')
@@ -413,7 +407,6 @@ test_that("middle of transition != after when duration=2000", {
         after=after.width)
   expect_true(during.width != after.width)
 })
-
 
 remDr$Runtime$evaluate("var e = document.getElementById('plot_duration_ms_year'); e.value = 0;e.dispatchEvent(new Event('change'));")
 Sys.sleep(1)

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -37,7 +37,7 @@ expect_source(NULL)
 
 clickSelector <- function(selectorName) {  
   script.txt <- sprintf('childDom = document.getElementsByClassName("%s")[0]; childDom.getElementsByClassName("selectize-input")[0].dispatchEvent(new CustomEvent("click"));', selectorName)
-  remDr$Runtime$evaluate(script.txt)
+  runtime_evaluate(script=script.txt)
 }
 
 test_that("bottom of widerect is above line", {  
@@ -339,14 +339,13 @@ test_that("pause stops animation (third time)", {
   expect_true(old.year == new.year)
 })
 
-remDr$Runtime$evaluate("document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
+runtime_evaluate(script="document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
 clickSelector("year_variable_selector_widget")
 sendKey("Backspace", "Backspace", 8)
 remDr$Input$insertText(text = "1962")
 clickSelector("year_variable_selector_widget")
 sendKey("ArrowDown", "ArrowDown", 40)
 sendKey("Enter", "Enter", 13)
-   
 Sys.sleep(3)
 
 test_that("typing into selectize widget changes year to 1962", {
@@ -408,7 +407,7 @@ test_that("middle of transition != after when duration=2000", {
   expect_true(during.width != after.width)
 })
 
-remDr$Runtime$evaluate("var e = document.getElementById('plot_duration_ms_year'); e.value = 0;e.dispatchEvent(new Event('change'));")
+runtime_evaluate(script="var e = document.getElementById('plot_duration_ms_year'); e.value = 0;e.dispatchEvent(new Event('change'));")
 Sys.sleep(1)
 
 test_that("middle of transition == after when duration=0", {

--- a/tests/testthat/test-renderer2-widerect.R
+++ b/tests/testthat/test-renderer2-widerect.R
@@ -339,7 +339,6 @@ test_that("pause stops animation (third time)", {
   expect_true(old.year == new.year)
 })
 
-#runtime_evaluate(script="document.getElementsByClassName('show_hide_selector_widgets')[0].dispatchEvent(new CustomEvent('click'));")
 runtime_evaluate_helper(class_name="show_hide_selector_widgets",list_num=0,dispatch_event=TRUE)
 clickSelector("year_variable_selector_widget")
 sendKey("Backspace", "Backspace", 8)

--- a/tests/testthat/test-shiny.R
+++ b/tests/testthat/test-shiny.R
@@ -2,7 +2,9 @@ acontext("shiny")
 
 ## We do not need if(on wercker or travis){skip shiny test} as of 10
 ## Oct 2015, since we only run tests that match the TEST_SUITE env
-## var, and test-shiny.R never matches.
+## var, and test-shiny.R never matches. TODO convert
+## sendKeysToActiveElement to new sendKeys, get shiny tests working on
+## new chromote framework.
 
 ## shiny tests require navigating to different ports, so remember
 ## where we are and return when tests are done


### PR DESCRIPTION
Use chromote as a headless browser for running tests and migrate tests to work with chromote. 

Closes #124 

Closes #125 

