### PR TITLE
fix guided tour for variable/value aes (named clickSelects/showSelected)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2025.1.24
+Version: 2025.1.25
 URL: https://animint.github.io/animint2/
 BugReports: https://github.com/animint/animint2/issues
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -287,4 +287,3 @@ Collate:
 RoxygenNote: 7.3.2
 Config/Needs/website: tidyverse/tidytemplate
 VignetteBuilder: knitr
-Remotes: rstudio/chromote

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in version 2025.1.25 (PR#182)
+
+- Tour text includes selector names for geoms with named clickSelects/showSelected.
+
 # Changes in version 2025.1.24 (PR#164)
 
 - New Start Tour widget at the bottom of each data viz, which highlights what interactions are possible with each geom. Use `geom_*(title="title for geom in tour", help="details about what this geom is supposed to represent)` to change what is displayed for each geom during the tour. Powered by https://driverjs.com/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Changes in version 2025.1.25 (PR#182)
 
 - Tour text includes selector names for geoms with named clickSelects/showSelected.
+- `animint2pages(chromote_sleep_seconds=NULL)` is the new default (no screenshot).
 
 # Changes in version 2025.1.24 (PR#164)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Tour text includes selector names for geoms with named clickSelects/showSelected.
 - `animint2pages(chromote_sleep_seconds=NULL)` is the new default (no screenshot).
+- knit_print.animint supports Start Tour button.
 
 # Changes in version 2025.1.24 (PR#164)
 

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -68,7 +68,7 @@ parsePlot <- function(meta, plot, plot.name){
     ## -> handles .value/.variable named params
     ## -> removes duplicates
     ## -> removes duplicates due to showSelected legend
-    L$extra_params <- checkExtraParams(L$extra_params, L$mapping)
+    L$extra_params <- checkExtraParams(L$extra_params, L$mapping, L$data)
 
     ## Add the showSelected/clickSelects params to the aesthetics
     ## mapping before calling ggplot_build

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -31,9 +31,7 @@ addShowSelectedForLegend <- function(meta, legend, L){
         ## used by the geom
         type.vec <- one.legend$legend_type
         if(any(type.vec %in% names(L$mapping))){
-          type.str <- paste(type.vec, collapse="")
-          a.name <- paste0("showSelectedlegend", type.str)
-          L$mapping[[a.name]] <- as.symbol(s.name)
+          L$extra_params$showSelected <- c(L$extra_params$showSelected, s.name)
         }
       }
       ## if selector.types has not been specified, create it
@@ -1065,12 +1063,6 @@ checkExtraParams <- function(extra_params, aes_mapping, layer_df){
     }
     ## Remove duplicates
     ep <- ep[ !duplicated(ep) ]
-    ## Remove from extra_params if already added by legend
-    if(i=="showSelected"){
-      ss_added_by_legend <- aes_mapping[grepl(
-        "^showSelectedlegend", names(aes_mapping))]
-      ep <- ep[ !ep %in% ss_added_by_legend ]
-    }
     ## make help string for variable/value aes.
     named.i <- which(names(ep) != "")
     extra_params[[paste0("help_",i)]] <- if(length(named.i)==1){

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -1048,7 +1048,7 @@ addSSandCSasAesthetics <- function(aesthetics, extra_params){
 ##' and clickSelects values of the layer
 ##' @param aes_mapping aesthetics mapping of the layer
 ##' @return Modified \code{extra_params} list
-checkExtraParams <- function(extra_params, aes_mapping){
+checkExtraParams <- function(extra_params, aes_mapping, layer_df){
   cs.ss <- intersect(names(extra_params), c("showSelected", "clickSelects"))
   for(i in cs.ss){
     ep <- extra_params[[i]]
@@ -1070,6 +1070,18 @@ checkExtraParams <- function(extra_params, aes_mapping){
         "^showSelectedlegend", names(aes_mapping))]
       ep <- ep[ !ep %in% ss_added_by_legend ]
     }
+    ## make help string for variable/value aes.
+    named.i <- which(names(ep) != "")
+    named.str <- if(length(named.i)==1){
+      var.name <- names(ep)[[named.i]]
+      u.vals <- unique(layer_df[[var.name]])
+      if(length(u.vals)==1){
+        u.vals
+      }else{
+        sprintf("one of: [%s]", paste(u.vals, collapse=", "))
+      }
+    }
+    extra_params[[paste0("help_",i)]] <- c(ep[-named.i], named.str)
     extra_params[[i]] <- ep
   }
   extra_params

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -1072,16 +1072,17 @@ checkExtraParams <- function(extra_params, aes_mapping, layer_df){
     }
     ## make help string for variable/value aes.
     named.i <- which(names(ep) != "")
-    named.str <- if(length(named.i)==1){
+    extra_params[[paste0("help_",i)]] <- if(length(named.i)==1){
       var.name <- names(ep)[[named.i]]
       u.vals <- unique(layer_df[[var.name]])
-      if(length(u.vals)==1){
+      c(ep[-named.i], if(length(u.vals)==1){
         u.vals
       }else{
         sprintf("one of: [%s]", paste(u.vals, collapse=", "))
-      }
+      })
+    }else{
+      ep
     }
-    extra_params[[paste0("help_",i)]] <- c(ep[-named.i], named.str)
     extra_params[[i]] <- ep
   }
   extra_params

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -1078,7 +1078,12 @@ checkExtraParams <- function(extra_params, aes_mapping, layer_df){
       c(ep[-named.i], if(length(u.vals)==1){
         u.vals
       }else{
-        sprintf("one of: [%s]", paste(u.vals, collapse=", "))
+        disp.vals <- if(length(u.vals)>4){
+          c(u.vals[1:2], "...", u.vals[c(length(u.vals)-1, length(u.vals))])
+        }else{
+          u.vals
+        }
+        sprintf("one of: [%s]", paste(disp.vals, collapse=", "))
       })
     }else{
       ep

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -1047,6 +1047,7 @@ addSSandCSasAesthetics <- function(aesthetics, extra_params){
 ##' @param extra_params named list containing the details of showSelected
 ##' and clickSelects values of the layer
 ##' @param aes_mapping aesthetics mapping of the layer
+##' @param layer_df the data frame
 ##' @return Modified \code{extra_params} list
 checkExtraParams <- function(extra_params, aes_mapping, layer_df){
   cs.ss <- intersect(names(extra_params), c("showSelected", "clickSelects"))

--- a/R/z_knitr.R
+++ b/R/z_knitr.R
@@ -29,7 +29,9 @@ knit_print.animint <- function(x, options, ...) {
 <script type="text/javascript" src="%s/vendor/jquery-1.11.3.min.js"></script>
 <script type="text/javascript" src="%s/vendor/selectize.min.js"></script>
 <link rel="stylesheet" type="text/css" href="%s/vendor/selectize.css" />
-%s', dir, dir, dir, dir, dir, res)
+<script type="text/javascript" src="%s/vendor/driver.js.iife.js"></script>
+<link rel="stylesheet" href="%s/vendor/driver.css" />
+%s', dir, dir, dir, dir, dir, dir, dir, res)
   }
   knitr::asis_output(res, meta = list(animint = structure("", class = "animint")))
 }

--- a/R/z_pages.R
+++ b/R/z_pages.R
@@ -16,6 +16,7 @@
 #' @param required_opts Character vector of plot.list element names
 #'   which are checked (stop with an error if not present). Use
 #'   required_opts=NULL to skip check.
+#' @param chromote_sleep_seconds if numeric, chromote will be used to take a screenshot of the data viz, pausing this number of seconds to wait for rendering (experimental).
 #' @param ... Additional options passed onto \code{animint2dir}.
 #'
 #' @return The function returns the initialized GitHub repository object.
@@ -36,7 +37,7 @@
 #' }
 #' 
 #' @export
-animint2pages <- function(plot.list, github_repo, owner=NULL, commit_message = "Commit from animint2pages", private = FALSE, required_opts = c("title","source"), ...) {
+animint2pages <- function(plot.list, github_repo, owner=NULL, commit_message = "Commit from animint2pages", private = FALSE, required_opts = c("title","source"), chromote_sleep_seconds=NULL, ...) {
   for(opt in required_opts){
     if(!opt %in% names(plot.list)){
       stop(sprintf("plot.list does not contain option named %s, which is required by animint2pages", opt))
@@ -48,20 +49,19 @@ animint2pages <- function(plot.list, github_repo, owner=NULL, commit_message = "
       stop(sprintf("Please run `install.packages('%s')` before using this function", pkg))
     }
   }
-  
-  if(requireNamespace("chromote") && requireNamespace("magick")) {
+  res <- animint2dir(plot.list, open.browser = FALSE, ...)
+  if(requireNamespace("chromote") && requireNamespace("magick") && is.numeric(chromote_sleep_seconds)) {
     chrome.session <- chromote::ChromoteSession$new()
-    res <- animint2dir(plot.list, open.browser = FALSE, ...)
     #Find available port and start server
     portNum <- servr::random_port()
     normDir <- normalizePath(res$out.dir, winslash = "/", mustWork = TRUE)
     start_servr(serverDirectory = normDir, port = portNum, tmpPath = normDir)
-    Sys.sleep(3)
+    Sys.sleep(chromote_sleep_seconds)
     url <- sprintf("http://localhost:%d", portNum)
     chrome.session$Page$navigate(url)
     screenshot_path <- file.path(res$out.dir, "Capture.PNG")
     screenshot_full <- file.path(res$out.dir, "Capture_full.PNG")
-    Sys.sleep(3)
+    Sys.sleep(chromote_sleep_seconds)
     ## Capture screenshot
     chrome.session$screenshot(screenshot_full, selector = ".plot_content")
     image_raw <- magick::image_read(screenshot_full)

--- a/inst/examples/WorldBank-facets-map.R
+++ b/inst/examples/WorldBank-facets-map.R
@@ -85,6 +85,7 @@ wb.facets <- animint(
     geom_line(aes(
       year, life.expectancy, group=country, colour=region),
       clickSelects="country",
+      help="Time series of life expectancy, one line per country",
       data=TS(not.na),
       size=4,
       alpha=1,
@@ -93,6 +94,7 @@ wb.facets <- animint(
       year, life.expectancy, colour=region, label=country),
       showSelected="country",
       clickSelects="country",
+      help="Names of selected countries",
       data=TS(min.years),
       hjust=1)+
     ## TS2
@@ -100,6 +102,7 @@ wb.facets <- animint(
     geom_path(aes(
       fertility.rate, year, group=country, colour=region),
       clickSelects="country",
+      help="Time series of fertility rate, one line per country",
       data=TS2(not.na),
       size=4,
       alpha=1,
@@ -110,6 +113,7 @@ wb.facets <- animint(
       key=country), # key aesthetic for smooth transitions!
       clickSelects="country",
       showSelected="year",
+      help="Scatter plot for the selected year, one point per country",
       alpha=1,
       alpha_off=0.3,
       chunk_vars=character(),
@@ -119,6 +123,7 @@ wb.facets <- animint(
       key=country), #also use key here!
       showSelected=c("country", "year", "region"),
       clickSelects="country",
+      help="Names of selected countries",
       chunk_vars=character(),
       data=SCATTER(not.na))+
     scale_size_animint(breaks=10^(9:5))+
@@ -127,10 +132,12 @@ wb.facets <- animint(
       5, 85, label=paste0("year = ", year),
       key=1),
       showSelected="year",
+      title="Selected year",
       data=SCATTER(years))+
     ## MAP
     geom_polygon(aes(
       x, y, group=group, fill=region),
+      title="World map",
       clickSelects="country",
       color="black",
       color_off="transparent",
@@ -143,6 +150,7 @@ wb.facets <- animint(
   selector.types=list(country="multiple"),
   source="https://github.com/animint/animint2/blob/master/inst/examples/WorldBank-facets-map.R",
   out.dir="WorldBank-facets-map",
+  video="https://vimeo.com/1050117030",
   title="World Bank data (multiple selection, facets)")
 options(browser="firefox")
 wb.facets

--- a/inst/examples/test_knit_print.Rmd
+++ b/inst/examples/test_knit_print.Rmd
@@ -18,7 +18,8 @@ knit_meta()
 library(animint2)
 dat <- data.frame(x = 1:10, y = 1:10, label = rep(c("a178", "b934"), 5))
 animint(q = qplot(
-  x, y, data = dat, colour = label, 
+  x, y, data = dat, colour = label,
+  help="first plot",
   xlab = "first plot with color legend"))
 ```
 
@@ -26,7 +27,8 @@ Clicking on the plot above should not affect the plot below.
 
 ```{r plot.1.bottom}
 animint(q = qplot(
-  x, y, data = dat, colour = label, 
+  x, y, data = dat, colour = label,
+  help="second plot",
   xlab = "second plot with color legend"))
 ```
 

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -190,14 +190,16 @@ var animint = function (to_select, json_file) {
     var geom = g_info.classed;
     var title = g_info.params.title || g_info.classed;
     var helpText = g_info.params.help || '';
-    var showSelected = g_info.params.showSelected || '';
-    var clickSelects = g_info.params.clickSelects || '';
+    var help_showSelected = g_info.params.help_showSelected || '';
+    var help_clickSelects = g_info.params.help_clickSelects || '';
     var description = helpText;
     if(g_info.params.hasOwnProperty("showSelected")){
-      description += '<br>Data are shown for the current selection of: ' + g_info.params.showSelected;
+      if(description != "")description += '<br>';
+      description += 'Data are shown for the current selection of: ' + help_showSelected;
     }
     if(g_info.params.hasOwnProperty("clickSelects")){
-      description += '<br>Click to select: ' + g_info.params.clickSelects;
+      if(description != "")description += '<br>';
+      description += 'Click to select: ' + help_clickSelects;
     }
     if(description == ""){
       description = "No interactions available";

--- a/man/animint2pages.Rd
+++ b/man/animint2pages.Rd
@@ -11,6 +11,7 @@ animint2pages(
   commit_message = "Commit from animint2pages",
   private = FALSE,
   required_opts = c("title", "source"),
+  chromote_sleep_seconds = NULL,
   ...
 )
 }
@@ -31,6 +32,8 @@ repository should be private or not (default FALSE).}
 \item{required_opts}{Character vector of plot.list element names
 which are checked (stop with an error if not present). Use
 required_opts=NULL to skip check.}
+
+\item{chromote_sleep_seconds}{if numeric, chromote will be used to take a screenshot of the data viz, pausing this number of seconds to wait for rendering (experimental).}
 
 \item{...}{Additional options passed onto \code{animint2dir}.}
 }

--- a/man/checkExtraParams.Rd
+++ b/man/checkExtraParams.Rd
@@ -11,6 +11,8 @@ checkExtraParams(extra_params, aes_mapping, layer_df)
 and clickSelects values of the layer}
 
 \item{aes_mapping}{aesthetics mapping of the layer}
+
+\item{layer_df}{the data frame}
 }
 \value{
 Modified \code{extra_params} list

--- a/man/checkExtraParams.Rd
+++ b/man/checkExtraParams.Rd
@@ -4,7 +4,7 @@
 \alias{checkExtraParams}
 \title{Check \code{extra_params} argument for duplicates, non-named list}
 \usage{
-checkExtraParams(extra_params, aes_mapping)
+checkExtraParams(extra_params, aes_mapping, layer_df)
 }
 \arguments{
 \item{extra_params}{named list containing the details of showSelected

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -400,17 +400,17 @@ runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dis
     if(isTRUE(dispatch_event))".dispatchEvent(new CustomEvent('click'))"))
 }
 
-driverjs_click_class <- function(class_name){
+driverjs_click_class <- function(class_name,list_num=0){
   runtime_evaluate_helper(
     class_name = class_name,
-    list_num = 0,
+    list_num = list_num,
     dispatch_event = TRUE
   )
   Sys.sleep(1)
   driverjs_get()
 }
 
-driverjs_start <- function()driverjs_click_class("animint_start_tour")
+driverjs_start <- function(list_num=0)driverjs_click_class("animint_start_tour",list_num)
 driverjs_next <- function()driverjs_click_class("driver-popover-next-btn")
 
 driverjs_get <- function(html=getHTML()){

--- a/tests/testthat/test-compiler-ghpages.R
+++ b/tests/testthat/test-compiler-ghpages.R
@@ -33,7 +33,7 @@ test_that("animint2pages() returns list of meta-data", {
   ## https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-an-organization-repository says The fine-grained token must have the following permission set: "Administration" repository permissions (write)
   gh::gh("POST /orgs/animint-test/repos", name="animint2pages_test_repo")
   ## first run of animint2pages creates new data viz.
-  result_list <- animint2pages(viz, "animint2pages_test_repo", owner="animint-test")
+  result_list <- animint2pages(viz, "animint2pages_test_repo", owner="animint-test", chromote_sleep_seconds=3)
   result_list
   expect_match(result_list$owner_repo, "animint2pages_test_repo")
   expect_match(result_list$viz_url, "github.io/animint2pages_test_repo")
@@ -55,7 +55,7 @@ test_that("animint2pages() returns list of meta-data", {
     geom_point(aes(
       x, x),
       data=data.frame(x=1:5))
-  update_list <- animint2pages(viz.more, "animint2pages_test_repo", owner="animint-test")
+  update_list <- animint2pages(viz.more, "animint2pages_test_repo", owner="animint-test", chromote_sleep_seconds=3)
   tsv_files_updated <- get_tsv(update_list)
   expect_equal(length(tsv_files_updated), 2)
   expect_Capture(update_list)

--- a/tests/testthat/test-compiler-save-separate-chunks.R
+++ b/tests/testthat/test-compiler-save-separate-chunks.R
@@ -62,7 +62,6 @@ test_that("save separate chunks for geom_polygon", {
   out.dir <- file.path(getwd(), "FluView")
   unlink(out.dir, recursive = TRUE)
   animint2dir(viz, out.dir = out.dir, open.browser = FALSE)
-  
   common.chunk <-
     list.files(path = out.dir, pattern = "geom.+polygon.+chunk_common.tsv", 
                full.names = TRUE)
@@ -82,7 +81,6 @@ test_that("save separate chunks for geom_polygon", {
   varied.data <- read.csv(varied.chunks[idx], sep = "\t", comment.char = "")
   expect_equal(nrow(varied.data), length(unique(FluView$USpolygons$group)))
   expect_true(all(c("fill", "group") %in% names(varied.data)))
-  
   unlink(out.dir, recursive = TRUE)
 })
 
@@ -113,7 +111,6 @@ test_that("save separate chunks for geom_point without specifying group", {
   out.dir <- file.path(getwd(), "FluView-point")
   unlink(out.dir, recursive = TRUE)
   animint2dir(viz, out.dir = out.dir, open.browser = FALSE)
-  
   common.chunk <-
     list.files(path = out.dir, pattern = "geom.+point.+chunk_common.tsv", 
                full.names = TRUE)
@@ -127,9 +124,7 @@ test_that("save separate chunks for geom_point without specifying group", {
   varied.data <- read.csv(varied.chunks, sep = "\t", comment.char = "")
   expect_equal(nrow(varied.data), nrow(flu.points))
   expect_true(all(c("fill", "x", "y", "showSelected1") %in% names(varied.data)))
-  
   unlink(out.dir, recursive = TRUE)
-  
   ## force to split into chunks
   state.map <- p + 
     geom_point(aes(x = mean.long, y = mean.lat, fill = level),
@@ -144,7 +139,6 @@ test_that("save separate chunks for geom_point without specifying group", {
          stateMap = state.map,
          title = "FluView")
   animint2dir(viz, out.dir = out.dir, open.browser = FALSE)
-  
   common.chunk <-
     list.files(path = out.dir, pattern = "geom.+point.+chunk_common.tsv", 
                full.names = TRUE)
@@ -164,7 +158,6 @@ test_that("save separate chunks for geom_point without specifying group", {
   varied.data <- read.csv(varied.chunks[idx], sep = "\t", comment.char = "")
   expect_equal(nrow(varied.data), nrow(USdots))
   expect_true(all(c("fill", "group") %in% names(varied.data)))
-    
   unlink(out.dir, recursive = TRUE)
 })
 
@@ -232,7 +225,6 @@ test_that("save separate chunks for non-spatial geoms with repetitive field, mul
   out.dir <- file.path(getwd(), "WorldBank-all")
   unlink(out.dir, recursive=TRUE)
   info <- animint2dir(viz, out.dir = out.dir, open.browser = FALSE)
-  
   ## multiple vars selected
   common.chunk <-
     list.files(path = out.dir, pattern = "geom2_text.+chunk_common.tsv", 
@@ -247,7 +239,6 @@ test_that("save separate chunks for non-spatial geoms with repetitive field, mul
   varied.data <- read.csv(varied.chunks[1], sep = "\t", comment.char = "")
   expect_equal(nrow(varied.data), 1)
   expect_true(all(c("x", "y", "label", "key") %in% names(varied.data)))
-  
   ## single var selected
   common.chunk <-
     list.files(path = out.dir, pattern = "geom.+point.+chunk_common.tsv", 
@@ -261,8 +252,9 @@ test_that("save separate chunks for non-spatial geoms with repetitive field, mul
   ## test common.chunk
   common.data <- read.csv(common.chunk, sep = "\t", comment.char = "")
   expect_equal(nrow(common.data), length(unique.country.vec))
-  common.must.have <- c("colour", "clickSelects", "key", "showSelectedlegendcolour", "fill", "group")
+  common.must.have <- c("colour", "clickSelects", "key", "fill", "group")
   expect_true(all(common.must.have %in% names(common.data)))
+  expect_equal(length(grep("showSelected",names(common.data))),1)
   ## choose first varied.chunk to test
   chunk.info <- info$geoms$geom1_point_scatter$chunks
   year.str <- names(chunk.info)[[1]]
@@ -276,7 +268,6 @@ test_that("save separate chunks for non-spatial geoms with repetitive field, mul
   varied.must.have <-
     c("size", "x", "y", "tooltip", "group")
   expect_true(all(varied.must.have %in% names(varied.data)))
-  
   unlink(out.dir, recursive = TRUE)
 })
 
@@ -309,7 +300,6 @@ test_that("save separate chunks for non-spatial geoms with nest_order not being 
   out.dir <- file.path(getwd(), "breakpointError-single")
   unlink(out.dir, recursive = TRUE)
   animint2dir(viz, out.dir = out.dir, open.browser = FALSE)
-  
   common.chunk <-
     list.files(path = out.dir, pattern = "geom.+segment.+chunk_common.tsv", 
                full.names = TRUE)
@@ -333,6 +323,5 @@ test_that("save separate chunks for non-spatial geoms with nest_order not being 
   expect_equal(nrow(varied.data), expected.rows)
   must.have <- c("x", "xend", "y", "yend", "group")
   expect_true(all(must.have %in% names(varied.data)))
-  
   unlink(out.dir, recursive = TRUE)
 })

--- a/tests/testthat/test-renderer-driverjs.R
+++ b/tests/testthat/test-renderer-driverjs.R
@@ -10,7 +10,7 @@ wb_data <- data.frame(
   population = c(300, 100, 150, 310, 110, 160, 320, 120, 170, 330, 130, 180, 340, 140, 190, 350, 150, 200)
 )
 
-my_plot <- list(
+wb_viz <- list(
   pointPlot = ggplot(wb_data, aes(x = life_expectancy, y = fertility_rate)) +
     geom_point(
       aes(size = population, color = country),
@@ -27,16 +27,16 @@ my_plot <- list(
       color = "red"
     )
 )
-info <- animint2HTML(my_plot)
+info <- animint2HTML(wb_viz)
 
 djs.list <- driverjs_get(info$html)
-test_that("no title nor description initially", {
+test_that("World Bank no title nor description initially", {
   expect_identical(djs.list$title, list())
   expect_identical(djs.list$description, list())
 })
 
 djs.list.start <- driverjs_start()
-test_that("Check first element of tour after clicking 'start_tour'", {
+test_that("World Bank first element of Start Tour", {
   expect_identical(djs.list.start$title, list(
     text="One country",
     .attrs=c(
@@ -54,7 +54,7 @@ test_that("Check first element of tour after clicking 'start_tour'", {
 })
 
 djs.list.next <- driverjs_next()
-test_that("Check second element of tour after clicking 'Next'", {
+test_that("World Bank tour after clicking Next", {
   expect_identical(djs.list.next$title, list(
     text = "geom2_vline_vlinePlot",
     .attrs = c(
@@ -82,13 +82,13 @@ viz <- animint(
 info <- animint2HTML(viz)
 
 djs.list <- driverjs_get(info$html)
-test_that("no title nor description initially", {
+test_that("driver tallrect no title nor description initially", {
   expect_identical(djs.list$title, list())
   expect_identical(djs.list$description, list())
 })
 
 djs.list.start <- driverjs_start()
-test_that("Check first element of tour after clicking Start Tour", {
+test_that("driver tallrect Start Tour", {
   expect_identical(djs.list.start$title, list(
     text="geom1_line_pointRect",
     .attrs=c(
@@ -102,14 +102,13 @@ test_that("Check first element of tour after clicking Start Tour", {
 })
 
 djs.list.next <- driverjs_next()
-test_that("Check second element of tour after clicking 'Next'", {
+test_that("driver tallrect after clicking Next", {
   expect_identical(djs.list.next$title, list(
     text = "geom2_tallrect_pointRect",
     .attrs = c(
       class = "driver-popover-title",
       style = "display: block;")))
   expect_identical(djs.list.next$description, list(
-    br=NULL,
     text = "Data are shown for the current selection of: year",
     br=NULL,
     text = "Click to select: year",

--- a/tests/testthat/test-renderer-driverjs.R
+++ b/tests/testthat/test-renderer-driverjs.R
@@ -149,4 +149,3 @@ test_that("driver sel Start Tour", {
       class = "driver-popover-description",
       style = "display: block;")))
 })
-

--- a/tests/testthat/test-renderer-driverjs.R
+++ b/tests/testthat/test-renderer-driverjs.R
@@ -45,7 +45,7 @@ test_that("World Bank first element of Start Tour", {
   expect_identical(djs.list.start$description, list(
     text = "Each point represents life expectancy and fertility rate for a given country.",
     br = NULL,
-    text = "Data are shown for the current selection of: year",
+    text = "Data are shown for the current selection of: year,country",
     br = NULL,
     text = "Click to select: country",
     .attrs = c(
@@ -95,7 +95,7 @@ test_that("driver tallrect Start Tour", {
       class="driver-popover-title",
       style="display: block;")))
   expect_identical(djs.list.start$description, list(
-    text = "No interactions available",
+    text = "Data are shown for the current selection of: country",
     .attrs = c(
       class = "driver-popover-description",
       style = "display: block;")))

--- a/tests/testthat/test-renderer-driverjs.R
+++ b/tests/testthat/test-renderer-driverjs.R
@@ -117,3 +117,36 @@ test_that("driver tallrect after clicking Next", {
       style = "display: block;")))
 })
 
+sel_df <- data.frame(
+  selectorName=sprintf("model_%d_size", 1:10),
+  selectorValue=1:100)
+sel_viz <- animint(
+  points=ggplot()+
+    geom_point(aes(
+      selectorValue, selectorName),
+      data=sel_df,
+      size=5,
+      clickSelects=c(selectorName="selectorValue"))
+)
+info <- animint2HTML(sel_viz)
+
+djs.list <- driverjs_get(info$html)
+test_that("driver sel no title nor description initially", {
+  expect_identical(djs.list$title, list())
+  expect_identical(djs.list$description, list())
+})
+
+djs.list.start <- driverjs_start()
+test_that("driver sel Start Tour", {
+  expect_identical(djs.list.start$title, list(
+    text="geom1_point_points",
+    .attrs=c(
+      class="driver-popover-title",
+      style="display: block;")))
+  expect_identical(djs.list.start$description, list(
+    text = "Click to select: one of: [model_1_size, model_2_size, ..., model_9_size, model_10_size]",
+    .attrs = c(
+      class = "driver-popover-description",
+      style = "display: block;")))
+})
+

--- a/tests/testthat/test-renderer-driverjs.R
+++ b/tests/testthat/test-renderer-driverjs.R
@@ -2,7 +2,7 @@ library(animint2)
 library(testthat)
 library(XML)
 
-data <- data.frame(
+wb_data <- data.frame(
   year = rep(2000:2005, each = 3),
   country = rep(c("USA", "Canada", "Mexico"), times = 6),
   life_expectancy = c(78, 80, 76, 79, 81, 77, 80, 82, 78, 81, 83, 79, 82, 84, 80, 83, 85, 81),
@@ -11,7 +11,7 @@ data <- data.frame(
 )
 
 my_plot <- list(
-  pointPlot = ggplot(data, aes(x = life_expectancy, y = fertility_rate)) +
+  pointPlot = ggplot(wb_data, aes(x = life_expectancy, y = fertility_rate)) +
     geom_point(
       aes(size = population, color = country),
       title = "One country",
@@ -20,7 +20,7 @@ my_plot <- list(
       clickSelects = "country"
     ) +
     labs(title = "Life Expectancy vs. Fertility Rate", x = "Life Expectancy", y = "Fertility Rate"),
-  vlinePlot = ggplot(data, aes(x = life_expectancy, y = fertility_rate)) +
+  vlinePlot = ggplot(wb_data, aes(x = life_expectancy, y = fertility_rate)) +
     geom_vline(
       xintercept = 80,
       linetype = "dashed",
@@ -66,3 +66,55 @@ test_that("Check second element of tour after clicking 'Next'", {
       class = "driver-popover-description",
       style = "display: block;")))
 })
+
+viz <- animint(
+  pointRect=ggplot()+
+    geom_line(aes(
+      x = year,
+      y = fertility_rate,
+      group=country,
+      color = country),
+      data=wb_data,
+      )+
+    make_tallrect(wb_data, "year"),
+  duration=list(year=2000)
+)
+info <- animint2HTML(viz)
+
+djs.list <- driverjs_get(info$html)
+test_that("no title nor description initially", {
+  expect_identical(djs.list$title, list())
+  expect_identical(djs.list$description, list())
+})
+
+djs.list.start <- driverjs_start()
+test_that("Check first element of tour after clicking Start Tour", {
+  expect_identical(djs.list.start$title, list(
+    text="geom1_line_pointRect",
+    .attrs=c(
+      class="driver-popover-title",
+      style="display: block;")))
+  expect_identical(djs.list.start$description, list(
+    text = "No interactions available",
+    .attrs = c(
+      class = "driver-popover-description",
+      style = "display: block;")))
+})
+
+djs.list.next <- driverjs_next()
+test_that("Check second element of tour after clicking 'Next'", {
+  expect_identical(djs.list.next$title, list(
+    text = "geom2_tallrect_pointRect",
+    .attrs = c(
+      class = "driver-popover-title",
+      style = "display: block;")))
+  expect_identical(djs.list.next$description, list(
+    br=NULL,
+    text = "Data are shown for the current selection of: year",
+    br=NULL,
+    text = "Click to select: year",
+    .attrs = c(
+      class = "driver-popover-description",
+      style = "display: block;")))
+})
+

--- a/tests/testthat/test-renderer1-WorldBank-NA.R
+++ b/tests/testthat/test-renderer1-WorldBank-NA.R
@@ -67,10 +67,10 @@ common <- read.table(common.tsv, sep="\t", header=TRUE,
                      comment.char="", quote="")
 
 test_that("common chunk contains expected columns", {
-  expected.cols <-
-    c("ymin", "ymax", "xmin", "fill", "key",
-      "clickSelects", "showSelectedlegendfill",
-      "group")
+  expected.cols <- c(
+    "ymin", "ymax", "xmin", "fill", "key",
+    "clickSelects", "showSelected2",
+    "group")
   expect_identical(sort(names(common)), sort(expected.cols))
 })
 

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -169,7 +169,9 @@ test_that("knit driver start first plot", {
         class = "driver-popover-title", 
         style = "display: block;")),
     description = list(
-      text = "first plot", 
+      text = "first plot",
+      br=NULL,
+      text="Data are shown for the current selection of: label",
       .attrs = c(
         class = "driver-popover-description",
         style = "display: block;"
@@ -186,6 +188,8 @@ test_that("knit driver start second plot", {
         style = "display: block;")),
     description = list(
       text = "second plot", 
+      br=NULL,
+      text="Data are shown for the current selection of: label",
       .attrs = c(
         class = "driver-popover-description",
         style = "display: block;"

--- a/tests/testthat/test-renderer1-knit-print.R
+++ b/tests/testthat/test-renderer1-knit-print.R
@@ -91,32 +91,24 @@ plot1bottom <- get_elements("plot1bottom")
 
 test_that("clicking top legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
-  
   clickID("plot1top_q_label_variable_a178")
   expect_equal(get_circles(), list(5, 10))
-  
   clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(0, 10))
-  
   clickID("plot1top_q_label_variable_b934")
   expect_equal(get_circles(), list(5, 10))
-  
   clickID("plot1top_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
 
 test_that("clicking bottom legend adds/remove points", {
   expect_equal(get_circles(), list(10, 10))
-  
   clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 5))
-  
   clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 0))
-  
   clickID("plot1bottom_q_label_variable_b934")
   expect_equal(get_circles(), list(10, 5))
-  
   clickID("plot1bottom_q_label_variable_a178")
   expect_equal(get_circles(), list(10, 10))
 })
@@ -161,4 +153,41 @@ test_that("bottom widget adds/remove points", {
   expect_equal(get_circles(), list(10, 5))
   send("b")
   expect_equal(get_circles(), list(10, 10))
+})
+
+djs.init.list <- driverjs_get(html)
+test_that("knit driver initially shows nothing", {
+  expect_identical(djs.init.list, list(title=list(), description=list()))
+})
+
+djs.start0.list <- driverjs_start(0)
+test_that("knit driver start first plot", {
+  expect_identical(djs.start0.list, list(
+    title = list(
+      text = "geom1_point_q",
+      .attrs = c(
+        class = "driver-popover-title", 
+        style = "display: block;")),
+    description = list(
+      text = "first plot", 
+      .attrs = c(
+        class = "driver-popover-description",
+        style = "display: block;"
+    ))))
+})
+
+djs.start1.list <- driverjs_start(1)
+test_that("knit driver start second plot", {
+  expect_identical(djs.start1.list, list(
+    title = list(
+      text = "geom1_point_q",
+      .attrs = c(
+        class = "driver-popover-title", 
+        style = "display: block;")),
+    description = list(
+      text = "second plot", 
+      .attrs = c(
+        class = "driver-popover-description",
+        style = "display: block;"
+    ))))
 })


### PR DESCRIPTION
The PR improves the DriverJS functionality.
Before this PR the DriverJS description did not include selector names, for named clickSelects/showSelected.
This PR changes the compiler to add help_clickSelects and help_showSelected parameters to each geom in the plot.json, which include the selector names, taken from the data values in the case of named clickSelects/showSelected.