### PR TITLE
Adding aes(tooltip) using d3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,10 @@ Authors@R: c(
      comment="Animint2 GSoC 2023"),
     person("Siddhesh", "Deodhar",
      role="aut",
-     comment="Animint2 GSoC 2024"))
+     comment="Animint2 GSoC 2024"),
+    person("Suhaani", "Agarwal",
+     role="aut",
+     comment="Animint2 GSoC 2025"))
 Description: Functions are provided for defining animated,
  interactive data visualizations in R code, and rendering
  on a web page. The 2018 Journal of Computational and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2025.1.28
+Version: 2025.6.4
 URL: https://animint.github.io/animint2/
 BugReports: https://github.com/animint/animint2/issues
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in version 2025.6.4 (PR#197)
+
+- `aes(tooltip = "...")` now renders fast, lightweight tooltips using D3.
+
 # Changes in version 2025.1.28
 
 ## PR#185

--- a/R/aes.r
+++ b/R/aes.r
@@ -5,7 +5,7 @@ NULL
   "colour", "fg", "fill", "group", "hjust", "label", "linetype", "lower",
   "lty", "lwd", "max", "middle", "min", "pch", "radius", "sample", "shape",
   "size", "srt", "upper", "vjust", "weight", "width", "x", "xend", "xmax",
-  "xmin", "xintercept", "y", "yend", "ymax", "ymin", "yintercept", "z")
+  "xmin", "xintercept", "y", "yend", "ymax", "ymin", "yintercept", "z", "tooltip")
 
 .base_to_ggplot <- c(
   "col"   = "colour",

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1610,6 +1610,20 @@ var animint = function (to_select, json_file) {
     };
     doActions(enter);  // DO NOT DELETE!
     var has_tooltip = g_info.aes.hasOwnProperty("tooltip");
+    function positionTooltip(tooltip, content) {
+      var mouseX = 0, mouseY = 0;
+      try {
+        mouseX = (d3.event && d3.event.pageX) || 0;
+        mouseY = (d3.event && d3.event.pageY) || 0;
+      } catch (e) {
+        console.error("Error getting mouse position:", e);
+      }
+      tooltip
+        .html(content)
+        .style("left", (mouseX + TOOLTIP_HORIZONTAL_OFFSET) + "px")
+        .style("top", (mouseY - TOOLTIP_VERTICAL_OFFSET) + "px")
+        .style("opacity", 1);
+    }
     if(has_clickSelects || has_tooltip || has_clickSelects_variable){
       // Tooltip positioning constants
       var TOOLTIP_HORIZONTAL_OFFSET = 10; // pixels right of mouse pointer
@@ -1646,34 +1660,14 @@ var animint = function (to_select, json_file) {
             console.error("Error generating tooltip content:", e);
             return;
           }
-          var mouseX = 0, mouseY = 0;
-          try {
-            mouseX = (d3.event && d3.event.pageX) || 0;
-            mouseY = (d3.event && d3.event.pageY) || 0;
-          } catch(e) {
-            console.error("Error getting mouse position:", e);
-          }
-          tooltip
-            .html(content)
-            .style("left", (mouseX + TOOLTIP_HORIZONTAL_OFFSET) + "px")
-            .style("top", (mouseY - TOOLTIP_VERTICAL_OFFSET) + "px")
-            .style("opacity", 1);
+          positionTooltip(tooltip, content);
         })
         .on("mouseout.tooltip", function() {
           tooltip.style("opacity", 0)
           .html(null);
         })
         .on("mousemove.tooltip", function() {
-          var mouseX = 0, mouseY = 0;
-          try {
-            mouseX = (d3.event && d3.event.pageX) || 0;
-            mouseY = (d3.event && d3.event.pageY) || 0;
-          } catch(e) {
-            console.error("Error getting mouse position:", e);
-          }
-          tooltip
-            .style("left", (mouseX + TOOLTIP_HORIZONTAL_OFFSET) + "px")
-            .style("top", (mouseY - TOOLTIP_VERTICAL_OFFSET) + "px");
+          positionTooltip(tooltip, tooltip.html());
         });
     }
     if(Selectors.hasOwnProperty(selector_name)){

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1656,6 +1656,8 @@ var animint = function (to_select, json_file) {
         })
         .on("mouseout.tooltip", function() {
           tooltip.style("opacity", 0)
+          .style("left", null)
+          .style("top", null)
           .html(null);
         })
         .on("mousemove.tooltip", function() {

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1611,6 +1611,10 @@ var animint = function (to_select, json_file) {
     doActions(enter);  // DO NOT DELETE!
     var has_tooltip = g_info.aes.hasOwnProperty("tooltip");
     if(has_clickSelects || has_tooltip || has_clickSelects_variable){
+      // Tooltip positioning constants
+      var TOOLTIP_HORIZONTAL_OFFSET = 10; // pixels right of mouse pointer
+      var TOOLTIP_VERTICAL_OFFSET = 28;   // pixels above mouse pointer
+
       var text_fun;
       if(has_tooltip){
         text_fun = function(d){
@@ -1653,8 +1657,8 @@ var animint = function (to_select, json_file) {
           }
           tooltip
             .html(content)
-            .style("left", (mouseX + 10) + "px")
-            .style("top", (mouseY - 28) + "px")
+            .style("left", (mouseX + TOOLTIP_HORIZONTAL_OFFSET) + "px")
+            .style("top", (mouseY - TOOLTIP_VERTICAL_OFFSET) + "px")
             .style("opacity", 1);
         })
         .on("mouseout.tooltip", function() {
@@ -1670,8 +1674,8 @@ var animint = function (to_select, json_file) {
             console.error("Error getting mouse position:", e);
           }
           tooltip
-            .style("left", (mouseX + 10) + "px")
-            .style("top", (mouseY - 28) + "px");
+            .style("left", (mouseX + TOOLTIP_HORIZONTAL_OFFSET) + "px")
+            .style("top", (mouseY - TOOLTIP_VERTICAL_OFFSET) + "px");
         });
     }
     if(Selectors.hasOwnProperty(selector_name)){

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1612,11 +1612,9 @@ var animint = function (to_select, json_file) {
     var has_tooltip = g_info.aes.hasOwnProperty("tooltip");
     function positionTooltip(tooltip, content) {
       var mouseX = 0, mouseY = 0;
-      try {
-        mouseX = (d3.event && d3.event.pageX) || 0;
-        mouseY = (d3.event && d3.event.pageY) || 0;
-      } catch (e) {
-        console.error("Error getting mouse position:", e);
+      if (d3.event) {
+        mouseX = d3.event.pageX;
+        mouseY = d3.event.pageY;
       }
       tooltip
         .html(content)
@@ -1653,13 +1651,7 @@ var animint = function (to_select, json_file) {
       elements
         .on("mouseover.tooltip", function(d) {
           if (!d || typeof text_fun !== 'function') return;
-          var content;
-          try {
-            content = text_fun(d);
-          } catch(e) {
-            console.error("Error generating tooltip content:", e);
-            return;
-          }
+          var content = text_fun(d);
           positionTooltip(tooltip, content);
         })
         .on("mouseout.tooltip", function() {

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1635,8 +1635,6 @@ var animint = function (to_select, json_file) {
     : d3.select("#plot").append("div")
         .attr("class", "animint-tooltip")
         .style("opacity", 0);
-      // Remove existing title elements to avoid conflicts with tooltips
-      elements.selectAll("title").remove();
       // Add tooltip handlers
       elements
         .on("mouseover.tooltip", function(d) {

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1626,11 +1626,53 @@ var animint = function (to_select, json_file) {
 	  return d["clickSelects.variable"] + " " + d["clickSelects.value"];
 	};
       }
-      // if elements have an existing title, remove it.
+      var tooltip = d3.select("#plot").select(".animint-tooltip").node() 
+    ? d3.select(".animint-tooltip")
+    : d3.select("#plot").append("div")
+        .attr("class", "animint-tooltip")
+        .style("opacity", 0);
+      // Remove existing title elements to avoid conflicts with tooltips
       elements.selectAll("title").remove();
-      elements.append("svg:title")
-        .text(get_fun(text_fun))
-      ;
+      // Add tooltip handlers
+      elements
+        .on("mouseover.tooltip", function(d) {
+          if (!d || typeof text_fun !== 'function') return;
+          var content;
+          try {
+            content = text_fun(d);
+          } catch(e) {
+            console.error("Error generating tooltip content:", e);
+            return;
+          }
+          var mouseX = 0, mouseY = 0;
+          try {
+            mouseX = (d3.event && d3.event.pageX) || 0;
+            mouseY = (d3.event && d3.event.pageY) || 0;
+          } catch(e) {
+            console.error("Error getting mouse position:", e);
+          }
+          tooltip
+            .html(content)
+            .style("left", (mouseX + 10) + "px")
+            .style("top", (mouseY - 28) + "px")
+            .style("opacity", 1);
+        })
+        .on("mouseout.tooltip", function() {
+          tooltip.style("opacity", 0)
+          .html(null);
+        })
+        .on("mousemove.tooltip", function() {
+          var mouseX = 0, mouseY = 0;
+          try {
+            mouseX = (d3.event && d3.event.pageX) || 0;
+            mouseY = (d3.event && d3.event.pageY) || 0;
+          } catch(e) {
+            console.error("Error getting mouse position:", e);
+          }
+          tooltip
+            .style("left", (mouseX + 10) + "px")
+            .style("top", (mouseY - 28) + "px");
+        });
     }
     if(Selectors.hasOwnProperty(selector_name)){
       var milliseconds = Selectors[selector_name].duration;

--- a/inst/htmljs/styles.css
+++ b/inst/htmljs/styles.css
@@ -1,4 +1,4 @@
-.animint-tooltip {
+/* .animint-tooltip {
   position: absolute;
   padding: 8px;
   background: white;
@@ -11,4 +11,39 @@
   max-width: 300px;
   opacity: 0;
   transition: opacity 300ms ease-in-out;
+} */
+.animint-tooltip {
+  position: absolute;
+  padding: 10px 12px;
+  background: #fff;
+  border-radius: 6px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.15);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #333;
+  pointer-events: none;
+  z-index: 1000;
+  max-width: 300px;
+  opacity: 0;
+  transform: translateY(5px);
+  transition: opacity 200ms ease-out, transform 200ms ease-out;
+  border: 1px solid #eee;
+}
+
+.animint-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -5px;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px 5px 0;
+  border-style: solid;
+  border-color: #fff transparent transparent;
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.1));
+}
+
+.animint-tooltip.showing {
+  opacity: 1;
+  transform: translateY(0);
 }

--- a/inst/htmljs/styles.css
+++ b/inst/htmljs/styles.css
@@ -1,0 +1,14 @@
+.animint-tooltip {
+  position: absolute;
+  padding: 8px;
+  background: white;
+  border-radius: 4px;
+  box-shadow: 0 0 5px rgba(0,0,0,0.3);
+  font-family: sans-serif;
+  font-size: 12px;
+  pointer-events: none;
+  z-index: 1000;
+  max-width: 300px;
+  opacity: 0;
+  transition: opacity 300ms ease-in-out;
+}

--- a/inst/htmljs/styles.css
+++ b/inst/htmljs/styles.css
@@ -1,17 +1,3 @@
-/* .animint-tooltip {
-  position: absolute;
-  padding: 8px;
-  background: white;
-  border-radius: 4px;
-  box-shadow: 0 0 5px rgba(0,0,0,0.3);
-  font-family: sans-serif;
-  font-size: 12px;
-  pointer-events: none;
-  z-index: 1000;
-  max-width: 300px;
-  opacity: 0;
-  transition: opacity 300ms ease-in-out;
-} */
 .animint-tooltip {
   position: absolute;
   padding: 10px 12px;
@@ -29,21 +15,4 @@
   transform: translateY(5px);
   transition: opacity 200ms ease-out, transform 200ms ease-out;
   border: 1px solid #eee;
-}
-
-.animint-tooltip::after {
-  content: '';
-  position: absolute;
-  bottom: -5px;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px 5px 0;
-  border-style: solid;
-  border-color: #fff transparent transparent;
-  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.1));
-}
-
-.animint-tooltip.showing {
-  opacity: 1;
-  transform: translateY(0);
 }

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -409,7 +409,9 @@ get_element_bbox <- function(selector) {
       left: box.left,
       top: box.top,
       width: box.width,
-      height: box.height
+      height: box.height,
+      center_x: box.left + box.width / 2,
+      center_y: box.top + box.height / 2
     };
   })()", selector)
   runtime_evaluate(script)

--- a/tests/testthat/helper-functions.R
+++ b/tests/testthat/helper-functions.R
@@ -400,6 +400,21 @@ runtime_evaluate_helper <- function(class_name=NULL, id=NULL, list_num=NULL, dis
     if(isTRUE(dispatch_event))".dispatchEvent(new CustomEvent('click'))"))
 }
 
+# get the bounding box (position and size) of an element relative to the viewport.
+get_element_bbox <- function(selector) {
+  script <- sprintf("(() => {
+    const el = document.querySelector('%s');
+    const box = el.getBoundingClientRect();
+    return {
+      left: box.left,
+      top: box.top,
+      width: box.width,
+      height: box.height
+    };
+  })()", selector)
+  runtime_evaluate(script)
+}
+
 driverjs_click_class <- function(class_name,list_num=0){
   runtime_evaluate_helper(
     class_name = class_name,

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -9,7 +9,7 @@ viz <-
   list(scatter=ggplot()+
        geom_point(aes(life.expectancy, fertility.rate,
                       colour=region, size=population,
-                      tooltip=paste(country, "population", population),
+                      tooltip=paste(country, "population", population), id = country,
                       key=country), # key aesthetic for animated transitions!
                   clickSelects="country",
                   showSelected="year",
@@ -82,8 +82,9 @@ test_that("tooltip shows correct content for rect", {
   center_y <- rect_y + (rect_height / 2)
   
   # Simulate hover over rectangle center
-  remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = center_x, y = center_y)
-  Sys.sleep(0.5) # Wait for tooltip
+  remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = center_x + 10, y = center_y)
+  # (Adjust for 10px left margin in the plot)
+  Sys.sleep(0.5)
   
   # Check tooltip content matches expected
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
@@ -98,21 +99,21 @@ test_that("tooltip shows correct content for rect", {
 test_that("tooltip shows correct content for point", {
   point_node <- getNodeSet(
     info$html, 
-    '//g[@class="geom1_point_scatter"]//circle'
-  )[[2]]
-  cx = as.numeric(xmlGetAttr(point_node, "cx"))
-  cy = as.numeric(xmlGetAttr(point_node, "cy"))
-  # Simulate hover over the point
+    '//g[@class="geom1_point_scatter"]//circle[@id="China"]'
+  )[[1]]
+  cx <- as.numeric(xmlGetAttr(point_node, "cx"))
+  cy <- as.numeric(xmlGetAttr(point_node, "cy"))
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved", 
-    x = cx,
+    x = cx + 10,  # Adjust for 10px left margin in the plot
     y = cy
   )
   Sys.sleep(0.3)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   tooltip_text <- xmlValue(tooltip_div)
-  expect_match(tooltip_text, "population") # point tooltip should include "population"
-  # Clean up - move mouse away
+  # Verify tooltip contains expected content
+  expect_match(tooltip_text, "China population 916395000")
+  # Move mouse away to clean up
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
 })
 

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -81,13 +81,11 @@ test_that("tooltip shows correct content for rect", {
 test_that("tooltip shows correct content for point", {
   # Get circle position on viewport
   circle_position <- get_element_bbox('circle#China')
-  center_x <- circle_position$left + (circle_position$width / 2)
-  center_y <- circle_position$top + (circle_position$height / 2)
   # Hover over center of the circle
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",
-    x = center_x,
-    y = center_y
+    x = circle_position$center_x,
+    y = circle_position$center_y
   )
   Sys.sleep(0.3)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
@@ -104,12 +102,10 @@ test_that("tooltip shows correct content for geom_text", {
   Sys.sleep(0.2)
   # Get text position on viewport
   text_position <- get_element_bbox('text#text_China')
-  center_x <- text_position$left + text_position$width/2
-  center_y <- text_position$top + text_position$height/2
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",
-    x = center_x,
-    y = center_y
+    x = text_position$center_x,
+    y = text_position$center_y
   )
   Sys.sleep(0.2)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -66,16 +66,7 @@ test_that("animint-tooltip div exists with correct initial state", {
 
 test_that("tooltip shows correct content for rect", {
   # Get rect position on viewport
-  rect_position <- runtime_evaluate(
-  "(() => {
-      const rect = document.querySelector('rect.geom');
-      const box = rect.getBoundingClientRect();
-      return {
-        left: box.left,
-        top: box.top
-      };
-  })()"
-  )
+  rect_position <- get_element_bbox('rect.geom')
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = rect_position$left, y = rect_position$top)
   Sys.sleep(0.3)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
@@ -89,18 +80,7 @@ test_that("tooltip shows correct content for rect", {
 
 test_that("tooltip shows correct content for point", {
   # Get circle position on viewport
-  circle_position <- runtime_evaluate(
-    "(() => {
-        const circle = document.querySelector('circle#China');
-        const box = circle.getBoundingClientRect();
-        return {
-          left: box.left,
-          top: box.top,
-          width: box.width,
-          height: box.height
-        };
-    })()"
-  )
+  circle_position <- get_element_bbox('circle#China')
   center_x <- circle_position$left + (circle_position$width / 2)
   center_y <- circle_position$top + (circle_position$height / 2)
   # Hover over center of the circle

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -99,7 +99,7 @@ test_that("tooltip shows correct content for point", {
   point_node <- getNodeSet(
     info$html, 
     '//g[@class="geom1_point_scatter"]//circle'
-  )[[6]] # Ukraine is the 6th point in the scatter plot
+  )[[2]]
   cx = as.numeric(xmlGetAttr(point_node, "cx"))
   cy = as.numeric(xmlGetAttr(point_node, "cy"))
   # Simulate hover over the point
@@ -111,7 +111,7 @@ test_that("tooltip shows correct content for point", {
   Sys.sleep(0.3)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   tooltip_text <- xmlValue(tooltip_div)
-  expect_match(tooltip_text, "Ukraine population 48758333")
+  expect_match(tooltip_text, "population") # point tooltip should include "population"
   # Clean up - move mouse away
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
 })

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -14,7 +14,7 @@ viz <-
                   clickSelects="country",
                   showSelected="year",
                   data=WorldBank)+
-       geom_text(aes(life.expectancy, fertility.rate, label=country, tooltip = country, id = country,
+       geom_text(aes(life.expectancy, fertility.rate, label=country, tooltip = country, id=paste0("text_",country),
                      key=country), #also use key here!
                  showSelected=c("country", "year"),
                  data=WorldBank)+
@@ -103,7 +103,7 @@ test_that("tooltip shows correct content for geom_text", {
   clickID('China') # Select the circle corresponding to China for highlighting text
   Sys.sleep(0.2)
   # Get text position on viewport
-  text_position <- get_element_bbox('text#China')
+  text_position <- get_element_bbox('text#text_China')
   center_x <- text_position$left + text_position$width/2
   center_y <- text_position$top + text_position$height/2
   remDr$Input$dispatchMouseEvent(

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -55,13 +55,13 @@ subset(WorldBank, country=="United States" & year == 1975)$population
 subset(years, year==1975)
 
 info <- animint2HTML(viz)
-
+tooltip.xpath <- '//div[@class="animint-tooltip"]'
 test_that("animint-tooltip div exists with correct initial state", {
-  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')
+  tooltip_div <- getNodeSet(info$html, tooltip.xpath)
   expect_equal(length(tooltip_div), 1)
   # Check initial opacity is 0
-  style <- xmlGetAttr(tooltip_div[[1]], "style")
-  expect_match(style, "opacity: 0;")
+  opacity <- getStyleValue(info$html, tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
 })
 
 test_that("tooltip shows correct content for rect", {
@@ -69,7 +69,7 @@ test_that("tooltip shows correct content for rect", {
   rect_position <- get_element_bbox('rect.geom')
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = rect_position$left, y = rect_position$top)
   Sys.sleep(0.3)
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   tooltip_text <- xmlValue(tooltip_div)
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "187 not NA in 1975")
@@ -88,7 +88,7 @@ test_that("tooltip shows correct content for point", {
     y = circle_position$center_y
   )
   Sys.sleep(0.3)
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   tooltip_text <- xmlValue(tooltip_div)
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "China population 916395000")
@@ -108,7 +108,7 @@ test_that("tooltip shows correct content for geom_text", {
     y = text_position$center_y
   )
   Sys.sleep(0.2)
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   tooltip_text <- xmlValue(tooltip_div) 
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "China")
@@ -128,7 +128,8 @@ viz <- list(ex = ex_plot)
 info <- animint2HTML(viz)
 
 test_that("tooltip div exists with href elements", {
-  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')
+  tooltip_div <- getNodeSet(info$html, tooltip.xpath)
   expect_equal(length(tooltip_div), 1)
-  expect_match(xmlGetAttr(tooltip_div[[1]], "style"), "opacity: 0;")
+  opacity <- getStyleValue(info$html, tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
 })

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -103,9 +103,9 @@ test_that("tooltip shows correct content for geom_text", {
   clickID('China') # Select the circle corresponding to China for highlighting text
   Sys.sleep(0.2)
   # Get text position on viewport
-  us_bbox <- get_element_bbox('text#China')
-  center_x <- us_bbox$left + us_bbox$width/2
-  center_y <- us_bbox$top + us_bbox$height/2
+  text_position <- get_element_bbox('text#China')
+  center_x <- text_position$left + text_position$width/2
+  center_y <- text_position$top + text_position$height/2
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",
     x = center_x,

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -14,7 +14,7 @@ viz <-
                   clickSelects="country",
                   showSelected="year",
                   data=WorldBank)+
-       geom_text(aes(life.expectancy, fertility.rate, label=country,
+       geom_text(aes(life.expectancy, fertility.rate, label=country, tooltip = country, id = country,
                      key=country), #also use key here!
                  showSelected=c("country", "year"),
                  data=WorldBank)+
@@ -94,6 +94,28 @@ test_that("tooltip shows correct content for point", {
   tooltip_text <- xmlValue(tooltip_div)
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "China population 916395000")
+  # Move mouse away to clean up
+  remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
+  Sys.sleep(0.2)
+})
+
+test_that("tooltip shows correct content for geom_text", {
+  clickID('China') # Select the circle corresponding to China for highlighting text
+  Sys.sleep(0.2)
+  # Get text position on viewport
+  us_bbox <- get_element_bbox('text#China')
+  center_x <- us_bbox$left + us_bbox$width/2
+  center_y <- us_bbox$top + us_bbox$height/2
+  remDr$Input$dispatchMouseEvent(
+    type = "mouseMoved",
+    x = center_x,
+    y = center_y
+  )
+  Sys.sleep(0.2)
+  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_text <- xmlValue(tooltip_div) 
+  # Verify tooltip contains expected content
+  expect_match(tooltip_text, "China")
   # Move mouse away to clean up
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
 })

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -60,7 +60,7 @@ test_that("animint-tooltip div exists with correct initial state", {
   tooltip_div <- getNodeSet(info$html, tooltip.xpath)
   expect_equal(length(tooltip_div), 1)
   # Check initial opacity is 0
-  opacity <- getStyleValue(info$html, tooltip.xpath, "opacity")
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
   expect_identical(opacity, "0")
 })
 
@@ -73,9 +73,15 @@ test_that("tooltip shows correct content for rect", {
   tooltip_text <- xmlValue(tooltip_div)
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "187 not NA in 1975")
+  # Verify that tooltip opacity is now 1 (tooltip shown)
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "1")
   # Move mouse away to clean up
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
   Sys.sleep(0.2)
+  # Verify that tooltip hides correctly after mouseout
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
 })
 
 test_that("tooltip shows correct content for point", {
@@ -92,9 +98,15 @@ test_that("tooltip shows correct content for point", {
   tooltip_text <- xmlValue(tooltip_div)
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "China population 916395000")
+  # Verify that tooltip opacity is now 1 (tooltip shown)
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "1")
   # Move mouse away to clean up
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
   Sys.sleep(0.2)
+  # Verify that tooltip hides correctly after mouseout
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
 })
 
 test_that("tooltip shows correct content for geom_text", {
@@ -112,8 +124,14 @@ test_that("tooltip shows correct content for geom_text", {
   tooltip_text <- xmlValue(tooltip_div) 
   # Verify tooltip contains expected content
   expect_match(tooltip_text, "China")
+  # Verify that tooltip opacity is now 1 (tooltip shown)
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "1")
   # Move mouse away to clean up
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
+  # Verify that tooltip hides correctly after mouseout
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
 })
 
 # Test with href
@@ -130,6 +148,7 @@ info <- animint2HTML(viz)
 test_that("tooltip div exists with href elements", {
   tooltip_div <- getNodeSet(info$html, tooltip.xpath)
   expect_equal(length(tooltip_div), 1)
+  # Opacity is initially 0 when tooltip is hidden
   opacity <- getStyleValue(info$html, tooltip.xpath, "opacity")
   expect_identical(opacity, "0")
 })

--- a/tests/testthat/test-renderer1-tooltip.R
+++ b/tests/testthat/test-renderer1-tooltip.R
@@ -96,18 +96,22 @@ test_that("tooltip shows correct content for rect", {
 })
 
 test_that("tooltip shows correct content for point", {
+  point_node <- getNodeSet(
+    info$html, 
+    '//g[@class="geom1_point_scatter"]//circle'
+  )[[6]] # Ukraine is the 6th point in the scatter plot
+  cx = as.numeric(xmlGetAttr(point_node, "cx"))
+  cy = as.numeric(xmlGetAttr(point_node, "cy"))
+  # Simulate hover over the point
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved", 
-    x = 230.01787959856264, #coordinates for the circle corresponding to Country Myanmar
-    y = 177.9050016888368
+    x = cx,
+    y = cy
   )
-  Sys.sleep(0.5)
-  
-  # Check tooltip contains "year"
+  Sys.sleep(0.3)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   tooltip_text <- xmlValue(tooltip_div)
-  expect_match(tooltip_text, "Myanmar population 30640635")
-  
+  expect_match(tooltip_text, "Ukraine population 48758333")
   # Clean up - move mouse away
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
 })

--- a/tests/testthat/test-renderer1-variable-value.R
+++ b/tests/testthat/test-renderer1-variable-value.R
@@ -122,12 +122,12 @@ test_that("No widgets for .variable .value selectors", {
 circle.xpath <- '//svg[@id="plot_peaks"]//circle'
 title.xpath <- paste0(circle.xpath, '//title')
 
-test_that("clickSelects.variable tooltip/title", {
-  circle.list <- getNodeSet(info$html, circle.xpath)
-  expect_equal(length(circle.list), 3)
-  title.list <- getNodeSet(info$html, title.xpath)
-  title.vec <- sapply(title.list, xmlValue)
-  expect_identical(title.vec, paste("size.100.problem.1", 0:2))
+test_that("animint-tooltip exists due to clickSelects", {
+  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')
+  expect_equal(length(tooltip_div), 1)
+  # check that the tooltip has initial opactity 0
+  style <- xmlGetAttr(tooltip_div[[1]], "style")
+  expect_match(style, "opacity: 0;")
 })
 
 test_that("two lines rendered in first plot", {
@@ -291,11 +291,10 @@ test_that("changing problem downloads one chunk", {
                  1, 1, 1, 1,
                  0, 0, 0, 0))
 })
-
-test_that("clickSelects tooltip/title", {
-  circle.list <- getNodeSet(info$html, circle.xpath)
-  expect_equal(length(circle.list), 3)
-  title.list <- getNodeSet(info$html, title.xpath)
-  title.vec <- sapply(title.list, xmlValue)
-  expect_identical(title.vec, paste("size.100.problem.1peaks", 0:2))
+test_that("animint-tooltip exists due to clickSelects", {
+  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')
+  expect_equal(length(tooltip_div), 1)
+  # check that the tooltip has initial opactity 0
+  style <- xmlGetAttr(tooltip_div[[1]], "style")
+  expect_match(style, "opacity: 0;")
 })

--- a/tests/testthat/test-renderer1-variable-value.R
+++ b/tests/testthat/test-renderer1-variable-value.R
@@ -121,13 +121,14 @@ test_that("No widgets for .variable .value selectors", {
 
 circle.xpath <- '//svg[@id="plot_peaks"]//circle'
 title.xpath <- paste0(circle.xpath, '//title')
+tooltip.xpath <- '//div[@class="animint-tooltip"]'
 
 test_that("animint-tooltip exists due to clickSelects", {
-  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')
+  tooltip_div <- getNodeSet(info$html, tooltip.xpath)
   expect_equal(length(tooltip_div), 1)
   # check that the tooltip has initial opactity 0
-  style <- xmlGetAttr(tooltip_div[[1]], "style")
-  expect_match(style, "opacity: 0;")
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, 'opacity')
+  expect_identical(opacity, "0")
 })
 
 test_that("two lines rendered in first plot", {
@@ -292,9 +293,9 @@ test_that("changing problem downloads one chunk", {
                  0, 0, 0, 0))
 })
 test_that("animint-tooltip exists due to clickSelects", {
-  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')
+  tooltip_div <- getNodeSet(info$html, tooltip.xpath)
   expect_equal(length(tooltip_div), 1)
   # check that the tooltip has initial opactity 0
-  style <- xmlGetAttr(tooltip_div[[1]], "style")
-  expect_match(style, "opacity: 0;")
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, 'opacity')
+  expect_identical(opacity, "0")
 })

--- a/tests/testthat/test-renderer3-prostateLasso.R
+++ b/tests/testthat/test-renderer3-prostateLasso.R
@@ -99,19 +99,22 @@ clickID("arclength174")
 html.click2 <- getHTML()
 
 test_that("tallrect displays correct tooltip", {
-  tallrect_node <- getNodeSet(
-    info$html,
-    '//g[@class="geom3_tallrect_path"]//rect[@id="arclength101"]'
-  )[[1]]
-  # coordinates for hover simulation
-  rect_x <- as.numeric(xmlGetAttr(tallrect_node, "x"))
-  rect_y <- as.numeric(xmlGetAttr(tallrect_node, "y"))
-  rect_height <- as.numeric(xmlGetAttr(tallrect_node, "height"))
-  # Simulate hover over tallrect center
+  # Get tallrect position on the viewport
+  tallrect_position <- runtime_evaluate(
+  "(() => {
+      const rect = document.querySelector('g.geom3_tallrect_path rect#arclength101');
+      const box = rect.getBoundingClientRect();
+      return {
+        left: box.left,
+        top: box.top
+      };
+  })()"
+  )
+  #hover over the tallrect
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",
-    x = rect_x + 5, # Adjust for 5px left margin in the plot
-    y = rect_y + (rect_height/2) # Adjust y to hover over the rect center
+    x = tallrect_position$left,
+    y = tallrect_position$top
   )
   Sys.sleep(0.5)
   # Checking tooltip content

--- a/tests/testthat/test-renderer3-prostateLasso.R
+++ b/tests/testthat/test-renderer3-prostateLasso.R
@@ -99,11 +99,29 @@ clickID("arclength174")
 html.click2 <- getHTML()
 
 test_that("tallrect displays correct tooltip", {
-  r <- getGreyRect(html.click2)
-  child.list <- xmlChildren(r)
-  expect_identical(names(child.list), "title")
-  value.vec <- sapply(child.list, xmlValue)
-  expect_identical(paste(value.vec), "arclength 17.4461019561232")
+  tallrect_node <- getNodeSet(
+    info$html,
+    '//g[@class="geom3_tallrect_path"]//rect'
+  )[[5]] #fifth tallrect
+  # coordinates for hover simulation
+  rect_x <- as.numeric(xmlGetAttr(tallrect_node, "x"))
+  rect_y <- as.numeric(xmlGetAttr(tallrect_node, "y"))
+  
+  # Simulate hover over tallrect center
+  remDr$Input$dispatchMouseEvent(
+    type = "mouseMoved",
+    x = rect_x ,
+    y = rect_y + 20 # Adjust y to hover over the rect
+  )
+  print(paste("Hovering at:", rect_x, rect_y))
+  Sys.sleep(1)
+  # Checking tooltip content
+  tooltip_text <- xmlValue(getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]])
+  expect_match(tooltip_text, "arclength")
+  expect_match(tooltip_text, "\\d+\\.\\d+") # Check for numeric value
+  # Clean up - move mouse away
+  remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
+  Sys.sleep(0.5)
 })
 
 viz.time <- viz.no.time

--- a/tests/testthat/test-renderer3-prostateLasso.R
+++ b/tests/testthat/test-renderer3-prostateLasso.R
@@ -101,19 +101,19 @@ html.click2 <- getHTML()
 test_that("tallrect displays correct tooltip", {
   tallrect_node <- getNodeSet(
     info$html,
-    '//g[@class="geom3_tallrect_path"]//rect'
-  )[[5]] #fifth tallrect
+    '//g[@class="geom3_tallrect_path"]//rect[@id="arclength101"]'
+  )[[1]]
   # coordinates for hover simulation
   rect_x <- as.numeric(xmlGetAttr(tallrect_node, "x"))
   rect_y <- as.numeric(xmlGetAttr(tallrect_node, "y"))
-  
+  rect_height <- as.numeric(xmlGetAttr(tallrect_node, "height"))
   # Simulate hover over tallrect center
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",
-    x = rect_x ,
-    y = rect_y + 20 # Adjust y to hover over the rect
+    x = rect_x + 5, # Adjust for 5px left margin in the plot
+    y = rect_y + (rect_height/2) # Adjust y to hover over the rect center
   )
-  Sys.sleep(1)
+  Sys.sleep(0.5)
   # Checking tooltip content
   tooltip_text <- xmlValue(getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]])
   expect_match(tooltip_text, "arclength")

--- a/tests/testthat/test-renderer3-prostateLasso.R
+++ b/tests/testthat/test-renderer3-prostateLasso.R
@@ -113,7 +113,6 @@ test_that("tallrect displays correct tooltip", {
     x = rect_x ,
     y = rect_y + 20 # Adjust y to hover over the rect
   )
-  print(paste("Hovering at:", rect_x, rect_y))
   Sys.sleep(1)
   # Checking tooltip content
   tooltip_text <- xmlValue(getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]])

--- a/tests/testthat/test-renderer3-prostateLasso.R
+++ b/tests/testthat/test-renderer3-prostateLasso.R
@@ -100,16 +100,7 @@ html.click2 <- getHTML()
 
 test_that("tallrect displays correct tooltip", {
   # Get tallrect position on the viewport
-  tallrect_position <- runtime_evaluate(
-  "(() => {
-      const rect = document.querySelector('g.geom3_tallrect_path rect#arclength101');
-      const box = rect.getBoundingClientRect();
-      return {
-        left: box.left,
-        top: box.top
-      };
-  })()"
-  )
+  tallrect_position <- get_element_bbox("g.geom3_tallrect_path rect#arclength101")
   #hover over the tallrect
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -3,7 +3,7 @@ acontext("tooltip-interactivity")
 data("CO2")
 
 plot_viz <- ggplot() + 
-  geom_point(aes(conc, uptake, color=Treatment, tooltip=Plant , id = paste0(CO2$Plant, "_", seq_len(nrow(CO2)))), # Unique ID for every circle
+  geom_point(aes(conc, uptake, color=Treatment, tooltip=Plant , id = paste0(Plant, "_", seq_len(nrow(CO2)))), # Unique ID for every circle
              data = CO2)+
   geom_rect(aes(xmin=100, xmax=200, ymin=20, ymax=30, 
               tooltip="Test Rectangle"), alpha=0.5)

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -20,7 +20,7 @@ test_that("tooltip shows correct content on hover interaction", {
   rect_position <- get_element_bbox('g[class*=\"geom2_rect\"] rect')
   # Hover over the rect
   remDr$Input$dispatchMouseEvent(
-    type = "mouseMoved", 
+    type = "mouseMoved",
     x = rect_position$left,
     y = rect_position$top
   )
@@ -36,6 +36,7 @@ test_that("tooltip shows correct content on hover interaction", {
 test_that("Interactivity does not mess up tooltips", {
   # Hide all nonchilled points
   clickID("plot_p_Treatment_variable_nonchilled")
+  Sys.sleep(0.5)
   # Hover over a chilled point
   bbox_chilled <- get_element_bbox('circle#Qc1_22')
   remDr$Input$dispatchMouseEvent(
@@ -43,7 +44,7 @@ test_that("Interactivity does not mess up tooltips", {
     x = bbox_chilled$center_x,
     y = bbox_chilled$center_y
   )
-  Sys.sleep(0.2)
+  Sys.sleep(0.5)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   tooltip_text <- xmlValue(tooltip_div)
   expect_match(tooltip_text, "Qc1", info = "Expected tooltip for chilled point Qc1")
@@ -53,7 +54,7 @@ test_that("Interactivity does not mess up tooltips", {
   Sys.sleep(0.2)
 
   # Hover over a nonchilled point
-  bbox_nonchilled <- get_element_bbox('circle#Qn1_3')
+  bbox_nonchilled <- get_element_bbox('circle#Mn3_60')
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved",
     x = bbox_nonchilled$center_x,
@@ -62,7 +63,7 @@ test_that("Interactivity does not mess up tooltips", {
   Sys.sleep(0.2)
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   tooltip_text <- xmlValue(tooltip_div)
-  expect_match(tooltip_text, "Qn1", info = "Expected tooltip for nonchilled point Qn1")
+  expect_match(tooltip_text, "Mn3", info = "Expected tooltip for nonchilled point Qn1")
 
   # Move mouse away at the end
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -3,7 +3,7 @@ acontext("tooltip-interactivity")
 data("CO2")
 
 plot_viz <- ggplot() + 
-  geom_point(aes(conc, uptake, color=Treatment, tooltip=Plant),
+  geom_point(aes(conc, uptake, color=Treatment, tooltip=Plant , id = paste0(CO2$Plant, "_", seq_len(nrow(CO2)))), # Unique ID for every circle
              data = CO2)+
   geom_rect(aes(xmin=100, xmax=200, ymin=20, ymax=30, 
               tooltip="Test Rectangle"), alpha=0.5)
@@ -31,7 +31,41 @@ test_that("tooltip shows correct content on hover interaction", {
   expect_equal(xmlValue(tooltip_div), "Test Rectangle")
   # Simulate mouseout
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
-  clickID("background")
+})
+
+test_that("Interactivity does not mess up tooltips", {
+  # Hide all nonchilled points
+  clickID("plot_p_Treatment_variable_nonchilled")
+  # Hover over a chilled point
+  bbox_chilled <- get_element_bbox('circle#Qc1_22')
+  remDr$Input$dispatchMouseEvent(
+    type = "mouseMoved",
+    x = bbox_chilled$center_x,
+    y = bbox_chilled$center_y
+  )
+  Sys.sleep(0.2)
+  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_text <- xmlValue(tooltip_div)
+  expect_match(tooltip_text, "Qc1", info = "Expected tooltip for chilled point Qc1")
+
+  # show nonchilled points
+  clickID("plot_p_Treatment_variable_nonchilled")
+  Sys.sleep(0.2)
+
+  # Hover over a nonchilled point
+  bbox_nonchilled <- get_element_bbox('circle#Qn1_3')
+  remDr$Input$dispatchMouseEvent(
+    type = "mouseMoved",
+    x = bbox_nonchilled$center_x,
+    y = bbox_nonchilled$center_y
+  )
+  Sys.sleep(0.2)
+  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_text <- xmlValue(tooltip_div)
+  expect_match(tooltip_text, "Qn1", info = "Expected tooltip for nonchilled point Qn1")
+
+  # Move mouse away at the end
+  remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
 })
 
 test_that("tooltip is hidden after mouseout", {

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -10,36 +10,40 @@ plot_viz <- ggplot() +
 viz <- list(p=plot_viz)
 info <- animint2HTML(viz)
 
-test_that("tooltip shows correct content on hover interaction", {
+test_that(".animint-tooltip exists and is hidden initially", {
   # Initial state - tooltip should be hidden
   tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')[[1]]
   expect_equal(xmlGetAttr(tooltip_div, "style"), "opacity: 0;")
-  
-  # Find the rectangle element
-  rect_node <- getNodeSet(info$html, '//g[contains(@class,"geom2_rect")]//rect')[[1]]
-  rect_x <- as.numeric(xmlGetAttr(rect_node, "x"))
-  rect_y <- as.numeric(xmlGetAttr(rect_node, "y"))
-  rect_width <- as.numeric(xmlGetAttr(rect_node, "width"))
-  rect_height <- as.numeric(xmlGetAttr(rect_node, "height"))
-  # Calculate center coordinates
-  rect_center_x <- rect_x + rect_width / 2
-  rect_center_y <- rect_y + rect_height / 2
-  # Simulate hover on rectangle
-  remDr$Input$dispatchMouseEvent(type = "mouseMoved", 
-                                x = rect_center_x + 10,  # Adjust for 10px left margin in the plot
-                                y = rect_center_y)
-  Sys.sleep(1)  # Wait for tooltip
+})
+test_that("tooltip shows correct content on hover interaction", {
+  # Get rectangle position on the viewport
+  rect_position <- runtime_evaluate(
+  "(() => {
+      const rect = document.querySelector('g[class*=\"geom2_rect\"] rect');
+      const box = rect.getBoundingClientRect();
+      return {
+        left: box.left,
+        top: box.top
+      };
+  })()"
+  )
+  # Hover over the rect
+  remDr$Input$dispatchMouseEvent(
+    type = "mouseMoved", 
+    x = rect_position$left,
+    y = rect_position$top
+  )
+  Sys.sleep(0.5)
   # Verify tooltip is visible and shows correct content
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   expect_match(xmlGetAttr(tooltip_div, "style"), "opacity: 1;")
   expect_equal(xmlValue(tooltip_div), "Test Rectangle")
-  
-  # Simulate mouseout (move mouse to background)
+  # Simulate mouseout
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
   clickID("background")
-  Sys.sleep(1)
-  
-  # Verify tooltip is hidden again
+})
+
+test_that("tooltip is hidden after mouseout", {
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   expect_match(xmlGetAttr(tooltip_div, "style"), "opacity: 0;")
   expect_equal(xmlValue(tooltip_div), "") # Content should be cleared

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -17,16 +17,7 @@ test_that(".animint-tooltip exists and is hidden initially", {
 })
 test_that("tooltip shows correct content on hover interaction", {
   # Get rectangle position on the viewport
-  rect_position <- runtime_evaluate(
-  "(() => {
-      const rect = document.querySelector('g[class*=\"geom2_rect\"] rect');
-      const box = rect.getBoundingClientRect();
-      return {
-        left: box.left,
-        top: box.top
-      };
-  })()"
-  )
+  rect_position <- get_element_bbox('g[class*=\"geom2_rect\"] rect')
   # Hover over the rect
   remDr$Input$dispatchMouseEvent(
     type = "mouseMoved", 

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -21,17 +21,14 @@ test_that("tooltip shows correct content on hover interaction", {
   rect_y <- as.numeric(xmlGetAttr(rect_node, "y"))
   rect_width <- as.numeric(xmlGetAttr(rect_node, "width"))
   rect_height <- as.numeric(xmlGetAttr(rect_node, "height"))
-  
   # Calculate center coordinates
   rect_center_x <- rect_x + rect_width / 2
   rect_center_y <- rect_y + rect_height / 2
-  
   # Simulate hover on rectangle
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", 
-                                x = rect_center_x, 
+                                x = rect_center_x + 10,  # Adjust for 10px left margin in the plot
                                 y = rect_center_y)
   Sys.sleep(1)  # Wait for tooltip
-  
   # Verify tooltip is visible and shows correct content
   tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
   expect_match(xmlGetAttr(tooltip_div, "style"), "opacity: 1;")

--- a/tests/testthat/test-renderer3-tooltip-interactivity.R
+++ b/tests/testthat/test-renderer3-tooltip-interactivity.R
@@ -10,10 +10,11 @@ plot_viz <- ggplot() +
 viz <- list(p=plot_viz)
 info <- animint2HTML(viz)
 
+tooltip.xpath <- '//div[@class="animint-tooltip"]'
 test_that(".animint-tooltip exists and is hidden initially", {
   # Initial state - tooltip should be hidden
-  tooltip_div <- getNodeSet(info$html, '//div[@class="animint-tooltip"]')[[1]]
-  expect_equal(xmlGetAttr(tooltip_div, "style"), "opacity: 0;")
+  opacity <- getStyleValue(info$html, tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
 })
 test_that("tooltip shows correct content on hover interaction", {
   # Get rectangle position on the viewport
@@ -26,8 +27,9 @@ test_that("tooltip shows correct content on hover interaction", {
   )
   Sys.sleep(0.5)
   # Verify tooltip is visible and shows correct content
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
-  expect_match(xmlGetAttr(tooltip_div, "style"), "opacity: 1;")
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "1")
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   expect_equal(xmlValue(tooltip_div), "Test Rectangle")
   # Simulate mouseout
   remDr$Input$dispatchMouseEvent(type = "mouseMoved", x = 0, y = 0)
@@ -45,7 +47,7 @@ test_that("Interactivity does not mess up tooltips", {
     y = bbox_chilled$center_y
   )
   Sys.sleep(0.5)
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   tooltip_text <- xmlValue(tooltip_div)
   expect_match(tooltip_text, "Qc1", info = "Expected tooltip for chilled point Qc1")
 
@@ -61,7 +63,7 @@ test_that("Interactivity does not mess up tooltips", {
     y = bbox_nonchilled$center_y
   )
   Sys.sleep(0.2)
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   tooltip_text <- xmlValue(tooltip_div)
   expect_match(tooltip_text, "Mn3", info = "Expected tooltip for nonchilled point Qn1")
 
@@ -70,7 +72,8 @@ test_that("Interactivity does not mess up tooltips", {
 })
 
 test_that("tooltip is hidden after mouseout", {
-  tooltip_div <- getNodeSet(getHTML(), '//div[@class="animint-tooltip"]')[[1]]
-  expect_match(xmlGetAttr(tooltip_div, "style"), "opacity: 0;")
+  opacity <- getStyleValue(getHTML(), tooltip.xpath, "opacity")
+  expect_identical(opacity, "0")
+  tooltip_div <- getNodeSet(getHTML(), tooltip.xpath)[[1]]
   expect_equal(xmlValue(tooltip_div), "") # Content should be cleared
 })


### PR DESCRIPTION
Resolves issue #179 

 - This PR changes the tooltip system from tippy.js (being implemented in PR #191 ) to a simpler D3 version. The tippy.js implementation was causing two main problems. First, it sometimes made the browser slow or unresponsive and caused chromote timeout issues , especially with many tooltips (hence certain tests were failing) . Second, it required adding extra JavaScript files that made the package bigger.

 - Since animint already uses D3 for everything else, I think it makes sense to use it for tooltips too. Here, This implementation creates a single tooltip div that gets added to the plot container. When hovering over any element with aes(tooltip) or clickSelects / showSelected , the tooltip's  position updates to follow the mouse and its content changes to show the specific tooltip text from the hovered element

 - The same div is reused for all tooltips - only its content and position change based on which element is being hovered. This avoids creating multiple tooltip elements, keeps everything in one place and also makes the tooltips faster . The tooltip hides automatically when moving the mouse away.
 
 - I have also modified the existing tooltip tests to support the new tooltip implementation.
 
 Is this implementation approach okay?