### PR TITLE
identical instead of ==

### DIFF
--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -750,7 +750,7 @@ getLegendList <- function(plistextra){
     }else{
       "legend"
     }
-    if(guide.type=="colourbar")guide.type <- "legend"
+    if(identical(guide.type,"colourbar"))guide.type <- "legend"
     guides.args[[aes.name]] <- guide.type
   }
   guides.result <- do.call(guides, guides.args)


### PR DESCRIPTION
this issue fixes a compiler error which happened here https://github.com/tdhock/hicream-viz/blob/main/data-2025-10-02/figure-pixels-volcano-interactive-heat-borders.R

Todo add a simpler test case.