### PR TITLE
Feature/multiline text and is no longer limited to just tooltips 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2025.10.3
+Version: 2025.10.8
 URL: https://animint.github.io/animint2/
 BugReports: https://github.com/animint/animint2/issues
 Authors@R: c(
@@ -276,6 +276,7 @@ Collate:
     'utilities-table.r'
     'uu_zxx.r'
     'uu_zzz.r'
+    'z_multiline.R'
     'z_animint.R'
     'z_animintHelpers.R'
     'z_facets.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in version 2025.10.8 (PR#221)
+
+- Multi-line text support: `\n` now works in plot titles, axis titles, legend titles, and `geom_text()` labels, not just tooltips. Created `R/z_multiline.R` with helper functions to convert `\n` to `<br/>` during R compilation (previously only done in JavaScript for tooltips). The JavaScript renderer converts `<br/>` to SVG `<tspan>` elements for proper multi-line display.
+
 # Changes in version 2025.10.3 (PR#240)
 
 - `guide_legend(override.aes)` works in a plot with both color and fill legends.

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -130,7 +130,7 @@ parsePlot <- function(meta, plot, plot.name){
   for (xy in c("x", "y")) {
     s <- function(tmp) sprintf(tmp, xy)
     # one axis name per plot (ie, a xtitle/ytitle is shared across panels)
-    plot.info[[s("%stitle")]] <- if(is.blank(s("axis.title.%s"))){
+    axis_title_raw <- if(is.blank(s("axis.title.%s"))){
       ""
     } else {
       scale.i <- which(plot$scales$find(xy))
@@ -143,6 +143,8 @@ parsePlot <- function(meta, plot, plot.name){
         lab.or.null
       }
     }
+    # Convert newlines to <br/> for multi-line axis titles (Issue #221)
+    plot.info[[s("%stitle")]] <- convertNewlinesToBreaks(axis_title_raw)
     ## panel text size.
     plot.info[[s("strip_text_%ssize")]] <- getTextSize(
       s("strip.text.%s"), theme.pars)
@@ -187,12 +189,13 @@ parsePlot <- function(meta, plot, plot.name){
   # grab the unique axis labels (makes rendering simpler)
   plot.info <- getUniqueAxisLabels(plot.info)
 
-  # grab plot title if present
-  plot.info$title <- if(is(theme.pars$plot.title, "blank")){
+  # grab plot title if present and convert newlines (Issue #221)
+  plot_title_raw <- if(is(theme.pars$plot.title, "blank")){
     ""
   }else{
     plot$labels$title
   }
+  plot.info$title <- convertNewlinesToBreaks(plot_title_raw)
   plot.info$title_size <- getTextSize("plot.title", theme.pars)
 
   ## Set plot width and height from animint.* options if they are
@@ -744,7 +747,8 @@ getLegendList <- function(plistextra){
     gdefs <- guides_merge(gdefs)
     gdefs <- guides_geom(gdefs, layers, default_mapping)
   } else (zeroGrob())
-  names(gdefs) <- sapply(gdefs, function(i) i$title)
+  # Use sanitized titles as names (convert newlines to spaces) to avoid JSON parsing issues (Issue #221)
+  names(gdefs) <- sapply(gdefs, function(i) gsub("\n", " ", i$title, fixed = TRUE))
 
   ## adding the variable used to each LegendList
   for(leg in seq_along(gdefs)) {

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -235,9 +235,6 @@ storeLayer <- function(meta, g, g.data.varied){
 #'   (be sure to configure your browser to allow access to local
 #'   files, as some browsers block this by default). Otherwise
 #'   (default) we use \code{servr::httd(out.dir)}.
-#' @param css.file character string for non-empty css file to
-#'   include. Provided file will be copied to the output directory as
-#'   styles.css
 #' @param chromote_sleep_seconds if numeric, chromote will be used to take a screenshot of the data viz, pausing this number of seconds to wait for rendering (experimental). Defaults to option \code{animint2.chromote_sleep_seconds}.
 #' @param chromote_width width of chromote window in pixels, default 3000 should be sufficient for most data viz, but can be increased if your data viz screenshot appears cropped too small.
 #' @param chromote_height height of chromote window in pixels, default 2000 should be sufficient for most data viz, but can be increased if your data viz screenshot appears cropped too small.
@@ -250,7 +247,6 @@ storeLayer <- function(meta, g, g.data.varied){
 animint2dir <- function
 (plot.list, out.dir = NULL,
   open.browser = interactive(),
-  css.file = "",
   chromote_sleep_seconds=getOption("animint2.chromote_sleep_seconds"),
   chromote_width=3000, chromote_height=2000
 ){
@@ -274,21 +270,6 @@ animint2dir <- function
   ## First, copy html/js/json files to out.dir.
   src.dir <- system.file("htmljs",package="animint2")
   to.copy <- Sys.glob(file.path(src.dir, "*"))
-  if(file.exists(paste0(out.dir, "styles.css")) | css.file != "default.file"){
-    to.copy <- to.copy[!grepl("styles.css", to.copy, fixed=TRUE)]
-  }
-  if(css.file!=""){
-    # if css filename is provided, copy that file to the out directory as "styles.css"
-    to.copy <- to.copy[!grepl("styles.css", to.copy, fixed=TRUE)]
-    if(!file.exists(css.file)){
-      stop(paste("css.file", css.file, "does not exist. Please check that the file name and path are specified correctly."))
-    } else {
-      file.copy(css.file, file.path(out.dir, "styles.css"), overwrite=TRUE)
-    }
-  } else {
-    style.file <- system.file("htmljs", "styles.css", package = "animint2")
-    file.copy(style.file, file.path(out.dir, "styles.css"), overwrite=TRUE)
-  }
   file.copy(to.copy, out.dir, overwrite=TRUE, recursive=TRUE)
 
   ## Store the animation information (time, var, ms) in a separate list

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -238,6 +238,9 @@ storeLayer <- function(meta, g, g.data.varied){
 #'   (be sure to configure your browser to allow access to local
 #'   files, as some browsers block this by default). Otherwise
 #'   (default) we use \code{servr::httd(out.dir)}.
+#' @param css.file character string for non-empty css file to
+#'   include. Provided file will be copied to the output directory as
+#'   styles.css
 #' @param chromote_sleep_seconds if numeric, chromote will be used to take a screenshot of the data viz, pausing this number of seconds to wait for rendering (experimental). Defaults to option \code{animint2.chromote_sleep_seconds}.
 #' @param chromote_width width of chromote window in pixels, default 3000 should be sufficient for most data viz, but can be increased if your data viz screenshot appears cropped too small.
 #' @param chromote_height height of chromote window in pixels, default 2000 should be sufficient for most data viz, but can be increased if your data viz screenshot appears cropped too small.
@@ -250,6 +253,7 @@ storeLayer <- function(meta, g, g.data.varied){
 animint2dir <- function
 (plot.list, out.dir = NULL,
   open.browser = interactive(),
+  css.file = "",
   chromote_sleep_seconds=getOption("animint2.chromote_sleep_seconds"),
   chromote_width=3000, chromote_height=2000
 ){
@@ -273,6 +277,21 @@ animint2dir <- function
   ## First, copy html/js/json files to out.dir.
   src.dir <- system.file("htmljs",package="animint2")
   to.copy <- Sys.glob(file.path(src.dir, "*"))
+  if(file.exists(paste0(out.dir, "styles.css")) | css.file != "default.file"){
+    to.copy <- to.copy[!grepl("styles.css", to.copy, fixed=TRUE)]
+  }
+  if(css.file!=""){
+    # if css filename is provided, copy that file to the out directory as "styles.css"
+    to.copy <- to.copy[!grepl("styles.css", to.copy, fixed=TRUE)]
+    if(!file.exists(css.file)){
+      stop(paste("css.file", css.file, "does not exist. Please check that the file name and path are specified correctly."))
+    } else {
+      file.copy(css.file, file.path(out.dir, "styles.css"), overwrite=TRUE)
+    }
+  } else {
+    style.file <- system.file("htmljs", "styles.css", package = "animint2")
+    file.copy(style.file, file.path(out.dir, "styles.css"), overwrite=TRUE)
+  }
   file.copy(to.copy, out.dir, overwrite=TRUE, recursive=TRUE)
 
   ## Store the animation information (time, var, ms) in a separate list

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -717,6 +717,8 @@ getLegend <- function(mb){
     names(data) <- paste0(geom, names(data))# aesthetics by geom
     names(data) <- gsub(paste0(geom, "."), "", names(data), fixed=TRUE) # label isn't geom-specific
     data$label <- paste(data$label) # otherwise it is AsIs.
+    # Convert newlines to <br/> for multi-line legend labels (Issue #221)
+    data$label <- convertNewlinesToBreaks(data$label)
     data
   }
   dataframes <- mapply(function(i, j) cleanData(i$data, mb$key, j, i$params),
@@ -741,10 +743,15 @@ getLegend <- function(mb){
   if(guidetype=="none"){
     NULL
   }else{
+    # Convert newlines to <br/> for multi-line legend title (Issue #221)
+    legend_title <- convertNewlinesToBreaks(mb$title)
+    # For the 'class' field (used as JSON key), keep original title without <br/>
+    # to avoid JSON parsing issues with special characters
+    legend_class <- if(mb$is.discrete) mb$selector else mb$title
     list(guide = guidetype,
          geoms = unlist(mb$geom.legend.list),
-         title = mb$title,
-         class = if(mb$is.discrete)mb$selector else mb$title,
+         title = legend_title,
+         class = legend_class,
          selector = mb$selector,
          is_discrete= mb$is.discrete,
          legend_type = mb$legend_type,
@@ -963,6 +970,10 @@ split_recursive <- function(x, vars){
 ##' @author Toby Dylan Hocking
 saveChunks <- function(x, meta){
   if(is.data.frame(x)){
+    # Convert newlines to <br/> in label column for multi-line text (Issue #221)
+    if("label" %in% names(x)){
+      x$label <- convertNewlinesToBreaks(x$label)
+    }
     this.i <- meta$chunk.i
     csv.name <- sprintf("%s_chunk%d.tsv", meta$g$classed, this.i)
     # Ensure fields are quoted so that embedded newlines or tabs in

--- a/R/z_multiline.R
+++ b/R/z_multiline.R
@@ -1,0 +1,110 @@
+#' Convert newline characters to HTML line breaks for text rendering
+#'
+#' @description
+#' This function converts literal newline characters (`\n`) in text strings
+#' to HTML `<br/>` tags. This enables multi-line text rendering in various
+#' plot elements including tooltips, axis titles, plot titles, legend entries,
+#' and geom_text labels.
+#'
+#' @details
+#' animint2 renders text in two contexts:
+#' 
+#' 1. **HTML context** (tooltips): Uses `<br/>` for line breaks
+#' 2. **SVG context** (titles, labels, legends): Also uses `<br/>` as a marker
+#'    that will be converted to `<tspan>` elements by JavaScript
+#'
+#' This function provides a centralized conversion that works for all text
+#' elements in animint2 visualizations, as suggested in issue #221.
+#'
+#' @param text Character vector or NULL. Text string(s) that may contain
+#'   newline characters (`\n`).
+#'
+#' @return Character vector with `\n` replaced by `<br/>`, or NULL if input
+#'   is NULL. Preserves the length and names of the input vector.
+#'
+#' @examples
+#' # Single string
+#' convertNewlinesToBreaks("First line\nSecond line")
+#' # Returns: "First line<br/>Second line"
+#' 
+#' # Vector of strings
+#' convertNewlinesToBreaks(c("One\nTwo", "Single", "A\nB\nC"))
+#' # Returns: c("One<br/>Two", "Single", "A<br/>B<br/>C")
+#' 
+#' # NULL input
+#' convertNewlinesToBreaks(NULL)
+#' # Returns: NULL
+#' 
+#' # Empty string
+#' convertNewlinesToBreaks("")
+#' # Returns: ""
+#'
+#' @seealso
+#' Used internally by:
+#' - `compileLayer()` for geom_text labels
+#' - `getLegend()` for legend entries
+#' - `getPlotInfo()` for axis and plot titles
+#'
+#' @keywords internal
+convertNewlinesToBreaks <- function(text) {
+  # Handle NULL input
+  if (is.null(text)) {
+    return(NULL)
+  }
+  
+  # Handle empty vectors
+  if (length(text) == 0) {
+    return(character(0))
+  }
+  
+  # Validate input type
+  if (!is.character(text) && !is.factor(text)) {
+    warning(
+      "convertNewlinesToBreaks expects character or factor input, got ",
+      class(text)[1],
+      ". Converting to character."
+    )
+    text <- as.character(text)
+  }
+  
+  # Convert factors to character to avoid issues
+  if (is.factor(text)) {
+    text <- as.character(text)
+  }
+  
+  # Preserve names if present
+  original_names <- names(text)
+  
+  # Perform the conversion: \n -> <br/>
+  # Using gsub with fixed=FALSE to handle literal \n in the string
+  result <- gsub("\n", "<br/>", text, fixed = TRUE)
+  
+  # Restore names
+  names(result) <- original_names
+  
+  return(result)
+}
+
+
+#' Check if text contains newline characters
+#'
+#' @description
+#' Helper function to quickly check if any strings in a character vector
+#' contain newline characters that would benefit from conversion.
+#'
+#' @param text Character vector to check
+#'
+#' @return Logical scalar indicating whether any element contains `\n`
+#'
+#' @examples
+#' hasNewlines("Regular text")  # FALSE
+#' hasNewlines("Text\nwith newline")  # TRUE
+#' hasNewlines(c("First", "Second\nLine"))  # TRUE
+#'
+#' @keywords internal
+hasNewlines <- function(text) {
+  if (is.null(text) || length(text) == 0) {
+    return(FALSE)
+  }
+  any(grepl("\n", text, fixed = TRUE))
+}

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -143,6 +143,43 @@ var animint = function (to_select, json_file) {
     return {height: bbox.height, width: bbox.width};
   };
 
+  /**
+   * Set multi-line text on SVG text elements
+   * Converts <br/> tags to <tspan> elements for proper SVG rendering
+   * @param {d3.selection} textElement - The D3 selection of <text> elements
+   * @param {string|function} text - Text string or function returning text
+   */
+  var setMultilineText = function(textElement, text) {
+    textElement.each(function(d) {
+      var textStr = typeof text === 'function' ? text(d) : text;
+      if (!textStr) return;
+      
+      var lines = String(textStr).split('<br/>');
+      var el = d3.select(this);
+      
+      // Clear existing content
+      el.text('');
+      
+      if (lines.length === 1) {
+        // Single line: use simple .text()
+        el.text(lines[0]);
+      } else {
+        // Multi-line: use <tspan> elements
+        var lineHeight = 1.2; // em units
+        var y = el.attr('y') || 0;
+        var x = el.attr('x') || 0;
+        var dy = 0;
+        
+        lines.forEach(function(line, i) {
+          el.append('tspan')
+            .attr('x', x)
+            .attr('dy', i === 0 ? 0 : lineHeight + 'em')
+            .text(line);
+        });
+      }
+    });
+  };
+
   var nest_by_group = d3.nest().key(function(d){ return d.group; });
   var dirs = json_file.split("/");
   dirs.pop(); //if a directory path exists, remove the JSON file from dirs
@@ -338,14 +375,16 @@ var animint = function (to_select, json_file) {
     if (p_info.title === undefined) titlepadding = 0;
     plotdim.title.x = p_info.options.width / 2;
     plotdim.title.y = titlepadding;
-    svg.append("text")
-      .text(p_info.title)
+    var titleText = svg.append("text")
       .attr("class", "plottitle")
       .attr("font-family", "sans-serif")
       .attr("font-size", p_info.title_size)
-      .attr("transform", "translate(" + plotdim.title.x + "," + 
-        plotdim.title.y + ")")
+      .attr("x", plotdim.title.x)
+      .attr("y", plotdim.title.y)
+      .attr("transform", "translate(0,0)")
       .style("text-anchor", "middle");
+    // Use multi-line text helper for plot titles (Issue #221)
+    setMultilineText(titleText, p_info.title);
 
     // grab max text size over axis labels and facet strip labels
     var axispaddingy = 5;
@@ -765,30 +804,25 @@ var animint = function (to_select, json_file) {
     } //end of for(layout_i
     // After drawing all backgrounds, we can draw the axis labels.
     if(p_info["ytitle"]){
-      svg.append("text")
-	.text(p_info["ytitle"])
+      var ytitleText = svg.append("text")
 	.attr("class", "ytitle")
+	.attr("x", ytitle_x)
+	.attr("y", (ytitle_top + ytitle_bottom)/2)
+	.attr("transform", "translate(0,0)rotate(270," + ytitle_x + "," + (ytitle_top + ytitle_bottom)/2 + ")")
 	.style("text-anchor", "middle")
-	.style("font-size", default_axis_px + "px")
-	.attr("transform", "translate(" + 
-	      ytitle_x +
-	      "," +
-	      (ytitle_top + ytitle_bottom)/2 + 
-	      ")rotate(270)")
-      ;
+	.style("font-size", default_axis_px + "px");
+      // Use multi-line text helper for y-axis title (Issue #221)
+      setMultilineText(ytitleText, p_info["ytitle"]);
     }
     if(p_info["xtitle"]){
-      svg.append("text")
-	.text(p_info["xtitle"])
+      var xtitleText = svg.append("text")
 	.attr("class", "xtitle")
+	.attr("x", (xtitle_left + xtitle_right)/2)
+	.attr("y", xtitle_y)
 	.style("text-anchor", "middle")
-	.style("font-size", default_axis_px + "px")
-	.attr("transform", "translate(" + 
-	      (xtitle_left + xtitle_right)/2 +
-	      "," + 
-	      xtitle_y + 
-	      ")")
-      ;
+	.style("font-size", default_axis_px + "px");
+      // Use multi-line text helper for x-axis title (Issue #221)
+      setMultilineText(xtitleText, p_info["xtitle"]);
     }
     Plots[p_name].scales = scales;
   }; //end of add_plot()
@@ -1489,11 +1523,11 @@ var animint = function (to_select, json_file) {
             .attr("y", toXY("y", "y"))
             .attr("font-size", get_size)
             .style("text-anchor", get_text_anchor)
-            .attr("transform", get_rotate)
-            .text(function (d) {
+            .attr("transform", get_rotate);
+          // Use multi-line text helper for geom_text labels (Issue #221)
+          setMultilineText(e, function (d) {
               return d.label;
-            })
-	  ;
+            });
 	};
 	eAppend = "text";
       }
@@ -2202,9 +2236,18 @@ var animint = function (to_select, json_file) {
       var first_th = first_tr.append("th")
 	.attr("align", "left")
 	.attr("colspan", 2)
-        .text(l_info.title)
         .attr("class", legend_class)
-        .style("font-size", l_info.title_size)
+        .style("font-size", l_info.title_size);
+      // Use multi-line text helper for legend title (Issue #221)
+      // Create a temporary span to set multi-line text
+      var tempSpan = first_th.append("span");
+      if (l_info.title && l_info.title.indexOf('<br/>') > -1) {
+        // Multi-line title: replace <br/> with actual line breaks in HTML
+        first_th.html(l_info.title.replace(/<br\/>/g, '<br/>'));
+      } else {
+        first_th.text(l_info.title);
+      }
+      first_th.select("span").remove(); // Clean up temp span if any
       ;
       var legend_svgs = legend_rows.append("td")
         .append("svg")

--- a/man/animint2dir.Rd
+++ b/man/animint2dir.Rd
@@ -8,7 +8,6 @@ animint2dir(
   plot.list,
   out.dir = NULL,
   open.browser = interactive(),
-  css.file = "",
   chromote_sleep_seconds = getOption("animint2.chromote_sleep_seconds"),
   chromote_width = 3000,
   chromote_height = 2000
@@ -27,10 +26,6 @@ determine how. If it is set to "browseURL" then we use a file URL
 (be sure to configure your browser to allow access to local
 files, as some browsers block this by default). Otherwise
 (default) we use \code{servr::httd(out.dir)}.}
-
-\item{css.file}{character string for non-empty css file to
-include. Provided file will be copied to the output directory as
-styles.css}
 
 \item{chromote_sleep_seconds}{if numeric, chromote will be used to take a screenshot of the data viz, pausing this number of seconds to wait for rendering (experimental). Defaults to option \code{animint2.chromote_sleep_seconds}.}
 

--- a/man/animint2dir.Rd
+++ b/man/animint2dir.Rd
@@ -8,6 +8,7 @@ animint2dir(
   plot.list,
   out.dir = NULL,
   open.browser = interactive(),
+  css.file = "",
   chromote_sleep_seconds = getOption("animint2.chromote_sleep_seconds"),
   chromote_width = 3000,
   chromote_height = 2000
@@ -26,6 +27,10 @@ determine how. If it is set to "browseURL" then we use a file URL
 (be sure to configure your browser to allow access to local
 files, as some browsers block this by default). Otherwise
 (default) we use \code{servr::httd(out.dir)}.}
+
+\item{css.file}{character string for non-empty css file to
+include. Provided file will be copied to the output directory as
+styles.css}
 
 \item{chromote_sleep_seconds}{if numeric, chromote will be used to take a screenshot of the data viz, pausing this number of seconds to wait for rendering (experimental). Defaults to option \code{animint2.chromote_sleep_seconds}.}
 

--- a/tests/testthat/test-compiler-multiline-text.R
+++ b/tests/testthat/test-compiler-multiline-text.R
@@ -1,0 +1,155 @@
+# Test for Issue #221: Multi-line text support throughout animint2
+# Tests that newline characters (\n) work in all text contexts
+
+library(animint2)
+library(testthat)
+
+context("Multi-line text rendering (Issue #221)")
+
+# Test 1: Plot title with newlines
+test_that("plot title supports multi-line text", {
+  data <- data.frame(x = 1:5, y = 1:5)
+  viz <- list(
+    plot1 = ggplot(data, aes(x, y)) +
+      geom_point() +
+      ggtitle("Title Line 1\nTitle Line 2")
+  )
+  info <- animint2dir(viz, "test-title-multiline", open.browser = FALSE)
+  json <- jsonlite::fromJSON(file.path(info$out.dir, "plot.json"))
+  expect_true(grepl("<br/>", json$plots$plot1$title, fixed = TRUE))
+  expect_equal(json$plots$plot1$title, "Title Line 1<br/>Title Line 2")
+})
+
+# Test 2: X-axis title with newlines
+test_that("x-axis title supports multi-line text", {
+  data <- data.frame(x = 1:5, y = 1:5)
+  viz <- list(
+    plot1 = ggplot(data, aes(x, y)) +
+      geom_point() +
+      xlab("X Axis\nLine 2")
+  )
+  info <- animint2dir(viz, "test-xaxis-multiline", open.browser = FALSE)
+  json <- jsonlite::fromJSON(file.path(info$out.dir, "plot.json"))
+  expect_true(grepl("<br/>", json$plots$plot1$xtitle, fixed = TRUE))
+  expect_equal(json$plots$plot1$xtitle, "X Axis<br/>Line 2")
+})
+
+# Test 3: Y-axis title with newlines
+test_that("y-axis title supports multi-line text", {
+  data <- data.frame(x = 1:5, y = 1:5)
+  viz <- list(
+    plot1 = ggplot(data, aes(x, y)) +
+      geom_point() +
+      ylab("Y Axis\nLine 2")
+  )
+  info <- animint2dir(viz, "test-yaxis-multiline", open.browser = FALSE)
+  json <- jsonlite::fromJSON(file.path(info$out.dir, "plot.json"))
+  expect_true(grepl("<br/>", json$plots$plot1$ytitle, fixed = TRUE))
+  expect_equal(json$plots$plot1$ytitle, "Y Axis<br/>Line 2")
+})
+
+# Test 4: geom_text labels with newlines
+test_that("geom_text labels support multi-line text", {
+  data <- data.frame(
+    x = 1:3,
+    y = 1:3,
+    label = c("One", "Two\nLines", "Three\nLines\nHere")
+  )
+  viz <- list(
+    plot1 = ggplot(data, aes(x, y, label = label)) +
+      geom_text()
+  )
+  info <- animint2dir(viz, "test-geomtext-multiline", open.browser = FALSE)
+  tsv_files <- list.files(info$out.dir, pattern = "text.*\\.tsv$", full.names = TRUE)
+  expect_true(length(tsv_files) > 0)
+  text_data <- read.table(tsv_files[1], header = TRUE, sep = "\t", quote = "\"")
+  multiline_labels <- text_data$label[grepl("<br/>", text_data$label, fixed = TRUE)]
+  expect_true(length(multiline_labels) >= 2)
+  expect_true(any(grepl("Two<br/>Lines", multiline_labels, fixed = TRUE)))
+  expect_true(any(grepl("Three<br/>Lines<br/>Here", multiline_labels, fixed = TRUE)))
+})
+
+# Test 5: Legend title with newlines
+test_that("legend title supports multi-line text", {
+  data <- data.frame(
+    x = 1:6,
+    y = 1:6,
+    category = rep(c("A", "B", "C"), 2)
+  )
+  viz <- list(
+    plot1 = ggplot(data, aes(x, y, color = category)) +
+      geom_point() +
+      scale_color_discrete(name = "Category\nName")
+  )
+  info <- animint2dir(viz, "test-legend-multiline", open.browser = FALSE)
+  json <- jsonlite::fromJSON(file.path(info$out.dir, "plot.json"))
+  expect_true("legend" %in% names(json$plots$plot1))
+  legend_keys <- names(json$plots$plot1$legend)
+  expect_true(length(legend_keys) > 0)
+  has_multiline_title <- FALSE
+  for (key in legend_keys) {
+    legend_title <- json$plots$plot1$legend[[key]]$title
+    if (!is.null(legend_title) && grepl("<br/>", legend_title, fixed = TRUE)) {
+      has_multiline_title <- TRUE
+      expect_equal(legend_title, "Category<br/>Name")
+      break
+    }
+  }
+  expect_true(has_multiline_title)
+})
+
+# Test 6: Tooltip text with newlines (already works, but let's ensure it still does)
+test_that("tooltip text supports multi-line text (regression test)", {
+  data <- data.frame(
+    x = 1:3,
+    y = 1:3,
+    tooltip = c("Single", "Two\nLines", "Three\nLines\nText")
+  )
+  viz <- list(
+    plot1 = ggplot(data, aes(x, y, tooltip = tooltip)) +
+      geom_point()
+  )
+  info <- animint2dir(viz, "test-tooltip-multiline", open.browser = FALSE)
+  tsv_files <- list.files(info$out.dir, pattern = "point.*\\.tsv$", full.names = TRUE)
+  expect_true(length(tsv_files) > 0)
+  point_data <- read.table(tsv_files[1], header = TRUE, sep = "\t", quote = "\"")
+  expect_true("tooltip" %in% names(point_data))
+  expect_true(any(grepl("\n", point_data$tooltip, fixed = TRUE)))
+})
+
+# Test 7: Helper function convertNewlinesToBreaks
+test_that("convertNewlinesToBreaks works correctly", {
+  expect_equal(
+    convertNewlinesToBreaks("Line1\nLine2"),
+    "Line1<br/>Line2"
+  )
+  expect_equal(
+    convertNewlinesToBreaks("A\nB\nC\nD"),
+    "A<br/>B<br/>C<br/>D"
+  )
+  expect_equal(
+    convertNewlinesToBreaks("No newlines here"),
+    "No newlines here"
+  )
+  expect_equal(
+    convertNewlinesToBreaks(""),
+    ""
+  )
+  expect_null(convertNewlinesToBreaks(NULL))
+  result <- convertNewlinesToBreaks(c("A\nB", "C", "D\nE\nF"))
+  expect_equal(result, c("A<br/>B", "C", "D<br/>E<br/>F"))
+})
+
+# Test 8: Helper function hasNewlines
+test_that("hasNewlines works correctly", {
+  expect_true(hasNewlines("Text\nwith newline"))
+  expect_false(hasNewlines("Text without newline"))
+  expect_true(hasNewlines(c("First", "Second\nLine")))
+  expect_false(hasNewlines(c("First", "Second")))
+  expect_false(hasNewlines(NULL))
+  expect_false(hasNewlines(character(0)))
+})
+
+cat("\n===============================================\n")
+cat("All multi-line text tests completed!\n")
+cat("===============================================\n")


### PR DESCRIPTION
## Add Multi-line Text Support Throughout animint2

Fixes #221

### Summary

This PR enables newline characters (`\n`) to work in **all text elements** of animint2 visualizations, not just tooltips. Users can now create multi-line text in plot titles, axis labels, legend titles, and text labels.

### What Now Works

✅ **Plot titles** - `ggtitle("Line 1\nLine 2")`  
✅ **X-axis titles** - `xlab("X Axis\nSubtitle")`  
✅ **Y-axis titles** - `ylab("Y Axis\nSubtitle")`  
✅ **Legend titles** - `scale_color_discrete(name="Legend\nTitle")`  
✅ **Text labels** - `geom_text(aes(label="Text\nLabel"))`  
✅ **Tooltips** - Already worked, still works (backward compatible)

### Visual Verification

The screenshot below shows a test visualization demonstrating multi-line text working in all contexts:

<img width="3072" height="1840" alt="Screenshot From 2025-10-08 19-58-25" src="https://github.com/user-attachments/assets/7a602a2c-1275-47d0-a25c-09dfa3d65d01" />


**What the screenshot shows:**
- **Plot title** (top center): "Multi-line Test" appears on one line, "Issue #221 Demonstration" appears below it
- **Y-axis title** (left side, vertical): "Y Axis" and "(Vertical Position)" are on separate lines
- **X-axis title** (bottom center): "X Axis" and "(Horizontal Position)" are on separate lines  
- **Legend title** (right side): "Data Group" and "(Click to Select)" are on separate lines
- **Point labels**: Some data points show text on multiple lines (e.g., "Two Lines" displays on two separate lines)

**Before this fix**, all newline characters (`\n`) displayed as literal text (you would see "Line1\nLine2" as one line with visible `\n` characters). **After this fix**, the text properly renders on separate lines with correct spacing.

### Example Usage

```r
library(animint2)

data <- data.frame(
  x = 1:5,
  y = 1:5,
  group = c("A", "B", "C", "A", "B"),
  label = c("Single", "Two\nLines", "Three\nLines\nHere", "Text", "Label")
)

viz <- animint(
  plot1 = ggplot(data, aes(x, y, color = group, label = label)) +
    geom_point(size = 5) +
    geom_text(vjust = -1) +
    ggtitle("Multi-line Test\nIssue #221 Demonstration") +
    xlab("X Axis\n(Horizontal Position)") +
    ylab("Y Axis\n(Vertical Position)") +
    scale_color_discrete(name = "Data Group\n(Click to Select)")
)

animint2dir(viz, "output-dir")