### PR TITLE
Fix #333: allow showSelected.legend=FALSE to keep explicit showSelected without legend auto-injection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in version 2026.6.5 (PR#336)
+
+- `geom(showSelected.legend=FALSE)` opts a layer out of auto-added legend showSelected while keeping explicit showSelected variables. (Fixed #333)
+
 # Changes in version 2026.4.28 (PR#292)
 
 - `geom(showSelected=character())` means to opt-out of interactive legends. Thanks @ANAMASGARD.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
 # Changes in version 2026.6.5 (PR#336)
 
-- `geom(showSelected.legend=FALSE)` opts a layer out of auto-added legend showSelected while keeping explicit showSelected variables. (Fixed #333)
+- `geom(showSelected.legend=FALSE)` is the canonical opt-out for legend-driven auto-injection of showSelected, including while keeping explicit showSelected variables. (Fixed #333)
+- Breaking API cleanup: PR #292 `geom(showSelected=character())` no longer opts out; use `showSelected.legend=FALSE` instead.
 
 # Changes in version 2026.4.28 (PR#292)
 
-- `geom(showSelected=character())` means to opt-out of interactive legends. Thanks @ANAMASGARD.
+- `geom(showSelected=character())` opted a layer out of auto-added legend showSelected (superseded by `showSelected.legend=FALSE` in PR#336). Thanks @ANAMASGARD.
 
 # Changes in version 2026.3.8 (PR#311)
 

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -58,7 +58,7 @@ parsePlot <- function(meta, plot, plot.name){
     class(L$mapping) <- "list"
 
     ## If any legends are specified, add showSelected aesthetic.
-    ## showSelected=character() opts this layer out of auto-injection only.
+    ## showSelected.legend=FALSE opts this layer out of legend auto-injection only.
     L <- addShowSelectedForLegend(meta, plot.info$legend, L)
 
     ## Check if showSelected and clickSelects have been used as aesthetics

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -6,11 +6,7 @@
 #' @param L layer of the plot
 #' @return L : Layer with additional mapping to new aesthetic
 addShowSelectedForLegend <- function(meta, legend, L){
-  ## Check if user explicitly disabled showSelected with character()
-  ## If showSelected is character(0), user wants to opt out of auto-showSelected
-  user_disabled_showSelected <- is.character(L$extra_params$showSelected) &&
-    length(L$extra_params$showSelected) == 0
-  user_disabled_legend_showSelected <- isFALSE(L$extra_params$showSelected.legend)
+  legend_auto_ss_disabled <- isFALSE(L$extra_params$showSelected.legend)
   for(legend.i in seq_along(legend)) {
     one.legend <- legend[[legend.i]]
     ## the name of the selection variable used in this legend.
@@ -35,9 +31,7 @@ addShowSelectedForLegend <- function(meta, legend, L){
         ## only add showSelected aesthetic if the variable is
         ## used by the geom
         type.vec <- one.legend$legend_type
-        if((!user_disabled_showSelected) &&
-           (!user_disabled_legend_showSelected) &&
-           any(type.vec %in% names(L$mapping))){
+        if(!legend_auto_ss_disabled && any(type.vec %in% names(L$mapping))){
           L$extra_params$showSelected <- c(L$extra_params$showSelected, s.name)
         }
       }

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -10,6 +10,7 @@ addShowSelectedForLegend <- function(meta, legend, L){
   ## If showSelected is character(0), user wants to opt out of auto-showSelected
   user_disabled_showSelected <- is.character(L$extra_params$showSelected) &&
     length(L$extra_params$showSelected) == 0
+  user_disabled_legend_showSelected <- isFALSE(L$extra_params$showSelected.legend)
   for(legend.i in seq_along(legend)) {
     one.legend <- legend[[legend.i]]
     ## the name of the selection variable used in this legend.
@@ -34,7 +35,9 @@ addShowSelectedForLegend <- function(meta, legend, L){
         ## only add showSelected aesthetic if the variable is
         ## used by the geom
         type.vec <- one.legend$legend_type
-        if((!user_disabled_showSelected) && any(type.vec %in% names(L$mapping))){
+        if((!user_disabled_showSelected) &&
+           (!user_disabled_legend_showSelected) &&
+           any(type.vec %in% names(L$mapping))){
           L$extra_params$showSelected <- c(L$extra_params$showSelected, s.name)
         }
       }
@@ -189,7 +192,10 @@ hjust2anchor <- function(hjust){
 error_for_showSelected_variants <- function(params) {
   if (is.null(names(params))) return(NULL)
   # Match any parameter that starts with "showSelected" but is not exactly "showSelected"
-  invalid_showSelected <- grep("^showSelected.+", names(params), value = TRUE)
+  invalid_showSelected <- setdiff(
+    grep("^showSelected.+", names(params), value = TRUE),
+    "showSelected.legend"
+  )
   if (length(invalid_showSelected) > 0) {
     stop(sprintf("Invalid parameter(s): %s. Please use geom(showSelected = character_vector_of_variable_names)",
         paste(invalid_showSelected, collapse = ", ")
@@ -206,6 +212,7 @@ error_for_showSelected_variants <- function(params) {
 getLayerParams <- function(l){
   params <- c(l$geom_params, l$stat_params, l$aes_params, l$extra_params)
   error_for_showSelected_variants(params)
+  params$showSelected.legend <- NULL
   if("chunk_vars" %in% names(params) && is.null(params[["chunk_vars"]])){
     params[["chunk_vars"]] <- character()
   }

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -186,10 +186,7 @@ hjust2anchor <- function(hjust){
 error_for_showSelected_variants <- function(params) {
   if (is.null(names(params))) return(NULL)
   # Match any parameter that starts with "showSelected" but is not exactly "showSelected"
-  invalid_showSelected <- setdiff(
-    grep("^showSelected.+", names(params), value = TRUE),
-    "showSelected.legend"
-  )
+  invalid_showSelected <- grep("^showSelected.+", names(params), value = TRUE)
   if (length(invalid_showSelected) > 0) {
     stop(sprintf("Invalid parameter(s): %s. Please use geom(showSelected = character_vector_of_variable_names)",
         paste(invalid_showSelected, collapse = ", ")
@@ -205,8 +202,8 @@ error_for_showSelected_variants <- function(params) {
 #' @return All parameters in the layer
 getLayerParams <- function(l){
   params <- c(l$geom_params, l$stat_params, l$aes_params, l$extra_params)
-  error_for_showSelected_variants(params)
   params$showSelected.legend <- NULL
+  error_for_showSelected_variants(params)
   if("chunk_vars" %in% names(params) && is.null(params[["chunk_vars"]])){
     params[["chunk_vars"]] <- character()
   }

--- a/R/z_animintHelpers.R
+++ b/R/z_animintHelpers.R
@@ -32,7 +32,7 @@ addShowSelectedForLegend <- function(meta, legend, L){
         ## used by the geom
         type.vec <- one.legend$legend_type
         if(!legend_auto_ss_disabled && any(type.vec %in% names(L$mapping))){
-          L$extra_params$showSelected <- c(L$extra_params$showSelected, s.name)
+          L$extra_params[["showSelected"]] <- c(L$extra_params[["showSelected"]], s.name)
         }
       }
       ## if selector.types has not been specified, create it

--- a/tests/testthat/test-renderer2-interactive-legends.R
+++ b/tests/testthat/test-renderer2-interactive-legends.R
@@ -251,7 +251,7 @@ viz <- list(
     ) +
     geom_segment(
       aes(x, y, xend = xend, yend = yend, color = comparison),
-      showSelected = character(),
+      showSelected.legend = FALSE,
       data = legend.opt.out.segments
     )
 )

--- a/tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R
+++ b/tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R
@@ -1,8 +1,7 @@
 acontext("opt out of showSelected legend but keep showSelected variable")
 ## Issue #333 https://github.com/animint/animint2/issues/333
-## showSelected=character() (PR #292) turns off all legend showSelected for a layer.
-## Here we want the opposite mix: keep showSelected="year" for filtering, but do not
-## auto-add region from colour=region when the legend is shown. API: showSelected.legend=FALSE.
+## Issue #333: keep showSelected="year" for filtering, but do not auto-add region from
+## colour=region when the legend is shown. API: showSelected.legend=FALSE.
 data(WorldBank, package = "animint2")
 issue333_viz <- function() {
   list(

--- a/tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R
+++ b/tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R
@@ -1,0 +1,47 @@
+acontext("opt out of showSelected legend but keep showSelected variable")
+## Issue #333 https://github.com/animint/animint2/issues/333
+## showSelected=character() (PR #292) turns off all legend showSelected for a layer.
+## Here we want the opposite mix: keep showSelected="year" for filtering, but do not
+## auto-add region from colour=region when the legend is shown. API: showSelected.legend=FALSE.
+data(WorldBank, package = "animint2")
+issue333_viz <- function() {
+  list(
+    scatter = ggplot() +
+      geom_point(
+        aes(fertility.rate, life.expectancy, colour = region, key = year),
+        showSelected = "year",
+        showSelected.legend = FALSE,
+        data = WorldBank
+      ),
+    ts = ggplot() + make_tallrect(WorldBank, "year"),
+    time = list(variable = "year", ms = 3000),
+    duration = list(year = 3000),
+    selector.types = list(year = "single"),
+    title = "issue333 opt out legend keep showSelected"
+  )
+}
+showSelected_variables <- function(info, plot.name = "scatter") {
+  geom.names <- names(info$geoms)
+  pat <- sprintf("_point_%s$", plot.name)
+  point.geom.name <- geom.names[grepl(pat, geom.names)]
+  stopifnot(length(point.geom.name) == 1)
+  aes.map <- info$geoms[[point.geom.name[[1]]]]$aes
+  ss.names <- grep("^showSelected", names(aes.map), value = TRUE)
+  as.character(unlist(aes.map[ss.names]))
+}
+info <- animint2dir(issue333_viz(), open.browser = FALSE)
+test_that("issue333 viz compiles with showSelected.legend=FALSE", {
+  expect_identical(info$time$variable, "year")
+})
+test_that("explicit showSelected=year without legend-injected region", {
+  expect_identical(showSelected_variables(info), "year")
+})
+test_that("colour legend for region is still compiled", {
+  legend.info <- info$plots$scatter$legend$region
+  expect_false(is.null(legend.info))
+  expect_gt(length(legend.info$entries), 0L)
+  expect_identical(legend.info$selector, "region")
+})
+test_that("year selector remains for animation and tallrect", {
+  expect_identical(info$selectors[["year"]]$type, "single")
+})

--- a/tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R
+++ b/tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R
@@ -37,7 +37,6 @@ test_that("explicit showSelected=year without legend-injected region", {
 })
 test_that("colour legend for region is still compiled", {
   legend.info <- info$plots$scatter$legend$region
-  expect_false(is.null(legend.info))
   expect_gt(length(legend.info$entries), 0L)
   expect_identical(legend.info$selector, "region")
 })

--- a/tests/testthat/test-renderer2-legend-without-showSelected.R
+++ b/tests/testthat/test-renderer2-legend-without-showSelected.R
@@ -29,12 +29,10 @@ test_that("default: legend with color aesthetic creates selector for interactivi
   expect_identical(legend_info$selector, "comparison")
   expect_identical("comparison" %in% names(info$selectors), TRUE)
 })
-test_that("showSelected=character() keeps legend selector but opts layer out", {
-  ## Proposed API: empty character vector disables auto showSelected injection
-  ## for this layer, but keeps legend interactivity intact.
+test_that("showSelected.legend=FALSE keeps legend selector but opts layer out", {
   viz_no_ss <- list(
     plot1 = ggplot(test_data, aes(x, y, color = comparison)) +
-      geom_point(showSelected = character()) +
+      geom_point(showSelected.legend = FALSE) +
       facet_wrap(~facet_var)
   )
   info <- animint2dir(viz_no_ss, open.browser = FALSE)
@@ -49,4 +47,17 @@ test_that("showSelected=character() keeps legend selector but opts layer out", {
   expect_identical(length(point_geom_name), 1L)
   show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
   expect_identical(any(grepl("^showSelected", show_aes_names)), FALSE)
+})
+test_that("showSelected=character() no longer opts layer out of legend injection", {
+  viz_char_ss <- list(
+    plot1 = ggplot(test_data, aes(x, y, color = comparison)) +
+      geom_point(showSelected = character()) +
+      facet_wrap(~facet_var)
+  )
+  info <- animint2dir(viz_char_ss, open.browser = FALSE)
+  geom_names <- names(info$geoms)
+  point_geom_name <- geom_names[grepl("_point_plot1$", geom_names)]
+  expect_identical(length(point_geom_name), 1L)
+  show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
+  expect_identical(any(grepl("^showSelected", show_aes_names)), TRUE)
 })

--- a/tests/testthat/test-renderer2-legend-without-showSelected.R
+++ b/tests/testthat/test-renderer2-legend-without-showSelected.R
@@ -49,6 +49,23 @@ test_that("showSelected.legend=FALSE keeps legend selector but opts layer out", 
   expect_identical(any(grepl("^showSelected", show_aes_names)), FALSE)
   expect_false("showSelected.legend" %in% names(info$geoms[[point_geom_name]]$params))
 })
+test_that("showSelected.legend=TRUE keeps default legend injection", {
+  viz <- list(
+    plot1 = ggplot(test_data, aes(x, y, color = comparison)) +
+      geom_point(showSelected.legend = TRUE) +
+      facet_wrap(~facet_var)
+  )
+  info <- animint2dir(viz, open.browser = FALSE)
+  legend_info <- info$plots$plot1$legend$comparison
+  expect_gt(length(legend_info$entries), 0)
+  expect_identical(legend_info$selector, "comparison")
+  geom_names <- names(info$geoms)
+  point_geom_name <- geom_names[grepl("_point_plot1$", geom_names)]
+  expect_identical(length(point_geom_name), 1L)
+  show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
+  expect_identical(any(grepl("^showSelected", show_aes_names)), TRUE)
+  expect_false("showSelected.legend" %in% names(info$geoms[[point_geom_name]]$params))
+})
 test_that("showSelected=character() no longer opts layer out of legend injection", {
   viz_char_ss <- list(
     legendInjectionPlot = ggplot(test_data, aes(x, y, color = comparison)) +

--- a/tests/testthat/test-renderer2-legend-without-showSelected.R
+++ b/tests/testthat/test-renderer2-legend-without-showSelected.R
@@ -47,16 +47,17 @@ test_that("showSelected.legend=FALSE keeps legend selector but opts layer out", 
   expect_identical(length(point_geom_name), 1L)
   show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
   expect_identical(any(grepl("^showSelected", show_aes_names)), FALSE)
+  expect_false("showSelected.legend" %in% names(info$geoms[[point_geom_name]]$params))
 })
 test_that("showSelected=character() no longer opts layer out of legend injection", {
   viz_char_ss <- list(
-    plot1 = ggplot(test_data, aes(x, y, color = comparison)) +
+    legendInjectionPlot = ggplot(test_data, aes(x, y, color = comparison)) +
       geom_point(showSelected = character()) +
       facet_wrap(~facet_var)
   )
   info <- animint2dir(viz_char_ss, open.browser = FALSE)
   geom_names <- names(info$geoms)
-  point_geom_name <- geom_names[grepl("_point_plot1$", geom_names)]
+  point_geom_name <- geom_names[grepl("_point_legendInjectionPlot$", geom_names)]
   expect_identical(length(point_geom_name), 1L)
   show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
   expect_identical(any(grepl("^showSelected", show_aes_names)), TRUE)

--- a/tests/testthat/test-renderer2-legend-without-showSelected.R
+++ b/tests/testthat/test-renderer2-legend-without-showSelected.R
@@ -63,7 +63,7 @@ test_that("showSelected.legend=TRUE keeps default legend injection", {
   point_geom_name <- geom_names[grepl("_point_plot1$", geom_names)]
   expect_identical(length(point_geom_name), 1L)
   show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
-  expect_identical(any(grepl("^showSelected", show_aes_names)), TRUE)
+  expect_match(show_aes_names, "^showSelected", all=FALSE)
   expect_false("showSelected.legend" %in% names(info$geoms[[point_geom_name]]$params))
 })
 test_that("showSelected=character() no longer opts layer out of legend injection", {
@@ -77,5 +77,5 @@ test_that("showSelected=character() no longer opts layer out of legend injection
   point_geom_name <- geom_names[grepl("_point_legendInjectionPlot$", geom_names)]
   expect_identical(length(point_geom_name), 1L)
   show_aes_names <- names(info$geoms[[point_geom_name]]$aes)
-  expect_identical(any(grepl("^showSelected", show_aes_names)), TRUE)
+  expect_match(show_aes_names, "^showSelected", all=FALSE)
 })


### PR DESCRIPTION
## Summary

Fixes https://github.com/animint/animint2/issues/333

PR #292 added `showSelected = character()` so a layer can opt out of **all** auto legend `showSelected` behavior while keeping the legend visible. Issue #333 asks for a narrower case: keep an **explicit** `showSelected` (e.g. filter by `year`) but **do not** auto-add `showSelected` for colour/fill legend variables on the same layer (e.g. `region` from `colour = region`).

## What was wrong?

On master, if you write `geom_point(..., colour = region, showSelected = "year")`, animint2 adds **both** `year` and `region` to the layer’s `showSelected` aesthetics. There was no way to suppress only the legend-driven part while keeping your own `showSelected`.

## What this PR does

**Commit 1 (this push): failing test only** — per [CONTRIBUTING](https://github.com/animint/animint2/blob/master/.github/CONTRIBUTING.md)

- Adds `tests/testthat/test-renderer2-issue333-opt-out-ss-with-other-showSelected.R`
- Uses proposed API: `geom(..., showSelected = "year", showSelected.legend = FALSE)`
- Asserts (once the API works):
  - Viz compiles
  - Layer `showSelected` is only `"year"` (not `"region"`)
  - Colour legend for `region` is still present
  - `year` selector stays `single` for animation / tallrect
- **Expected CI on commit 1:** red — error at `animint2dir()` because `error_for_showSelected_variants()` does not whitelist `showSelected.legend` yet

**Commit 2 (next): implementation**

- Whitelist `showSelected.legend` in `error_for_showSelected_variants()` (`R/z_animintHelpers.R`)
- In `addShowSelectedForLegend()`, when `isFALSE(extra_params$showSelected.legend)`, skip appending legend variables to `showSelected` (still honor user-specified `showSelected`)
- Strip `showSelected.legend` in `getLayerParams()` so it never appears in TSV/JSON export
- **Expected CI after commit 2:** green — same test file passes

## Expected result

Users can write:

```r
geom_point(aes(..., colour = region), showSelected = "year", showSelected.legend = FALSE)