### PR TITLE
fix: multi-line facet panel strip labels for facet_grid and facet_wrap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2026.7.29
+Version: 2026.8.23
 URL: https://animint.github.io/animint2
 BugReports: https://github.com/animint/animint2/issues
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in development (PR#XXX)
+
+- Multi-line facet strip labels: `facet_grid()` and `facet_wrap()` now render each facet variable on its own line, matching ggplot2 (issue #262).
+
 # Changes in version 2026.4.28 (PR#292)
 
 - `geom(showSelected=character())` means to opt-out of interactive legends. Thanks @ANAMASGARD.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Changes in development (PR#XXX)
+# Changes in development (PR#339)
 
 - Multi-line facet strip labels: `facet_grid()` and `facet_wrap()` now render each facet variable on its own line, matching ggplot2 (issue #262).
 
@@ -7,7 +7,6 @@
 - Multi-line text support (issue #221): `\n` now works in plot titles, axis titles, legend titles, and `geom_text()` labels. R compiler converts newlines to `<br/>` via `R/z_multiline.R`; JavaScript renderer converts `<br/>` to SVG `<tspan>` elements.
 - Fixed multiline text spacing: plot titles no longer overlap the plot area, and X/Y axis title spacing is consistent with single-line titles.
 - Fixed axis titles to scale correctly with `theme(text=element_text(size=X))` (issue #64).
-
 
 # Changes in version 2026.6.28 (PR#328)
 

--- a/R/z_facets.R
+++ b/R/z_facets.R
@@ -37,17 +37,22 @@ build_strip <- function(panel, label_df, labeller, side = "right", ...) {
   labels <- lapply(labeller(label_df), cbind)
   labels <- do.call("cbind", labels)
   # unlike ggplot2, we collapse "layers" of strips into 1 layer
-  apply(labels, 1, paste, collapse = "; ")
+  apply(labels, 1, paste, collapse = "\n")
 }
 
 #' @export
 getStrips.wrap <- function(facet, panel, ...) {
   labels_df <- panel$layout[names(facet$facets)]
-  labels_df[] <- plyr::llply(labels_df, format, justify = "none")
-  # facet_wrap labels always go on top
-  # we return a list so p_info.strips is always an object (on the JS side)
-  strips <- list(top = apply(labels_df, 1, paste, collapse = ", "), right = list(""))
-  # strips <- strips[!identical(strips$top, rep("", nrow(panel$layout)))]
+  attr(labels_df, "facet") <- "wrap"
+  if (is.null(facet$switch) || facet$switch == "x") {
+    attr(labels_df, "type") <- "rows"
+  } else {
+    attr(labels_df, "type") <- "cols"
+  }
+  strips <- list(
+    top = as.list(build_strip(panel, labels_df, facet$labeller, side = "top", ...)),
+    right = list("")
+  )
   strips$n <- list(top = max(panel$layout$ROW), right = 0)
   strips
 }

--- a/R/z_facets.R
+++ b/R/z_facets.R
@@ -37,7 +37,7 @@ build_strip <- function(panel, label_df, labeller, side = "right", ...) {
   labels <- lapply(labeller(label_df), cbind)
   labels <- do.call("cbind", labels)
   # unlike ggplot2, we collapse "layers" of strips into 1 layer
-  apply(labels, 1, paste, collapse = "\n")
+  convertNewlinesToBreaks(apply(labels, 1, paste, collapse = "\n"))
 }
 
 #' @export

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -192,6 +192,36 @@ var animint = function (to_select, json_file) {
     return {height: bbox.height, width: bbox.width};
   };
 
+  var measureMultilineText = function(pText, pFontSize, pAngle, pStyle) {
+    if (pText === undefined || pText === null || pText.length === 0) {
+      return {height: 0, width: 0};
+    }
+    var lines = pText.split("\n");
+    if (lines.length === 1) {
+      return measureText(pText, pFontSize, pAngle, pStyle);
+    }
+    var fontSize = parseFloat(pFontSize);
+    var sizes = lines.map(function(line) {
+      return measureText(line, pFontSize, pAngle, pStyle);
+    });
+    return {
+      height: (lines.length - 1) * fontSize * 1.2 +
+        d3.max(sizes, function(s) { return s.height; }),
+      width: d3.max(sizes, function(s) { return s.width; })
+    };
+  };
+
+  var setMultilineText = function(textSelection, label) {
+    var lines = label.split("\n");
+    textSelection.text("");
+    lines.forEach(function(line, i) {
+      textSelection.append("tspan")
+        .attr("x", 0)
+        .attr("dy", i === 0 ? "0em" : "1.2em")
+        .text(line);
+    });
+  };
+
   var nest_by_group = d3.nest().key(function(d){ return d.group; });
   var dirs = json_file.split("/");
   dirs.pop(); //if a directory path exists, remove the JSON file from dirs
@@ -443,10 +473,10 @@ var animint = function (to_select, json_file) {
     plotdim.margin = margin;
     
     var strip_heights = p_info.strips.top.map(function(entry){ 
-      return measureText(entry, p_info.strip_text_xsize).height;
+      return measureMultilineText(entry, p_info.strip_text_xsize).height;
     });
     var strip_widths = p_info.strips.right.map(function(entry){ 
-      return measureText(entry, p_info.strip_text_ysize).height; 
+      return measureMultilineText(entry, p_info.strip_text_ysize).height; 
     });
 
     // compute the number of x/y axes, max strip height per row, and
@@ -684,10 +714,8 @@ var animint = function (to_select, json_file) {
           .append("text")
           .style("text-anchor", "middle")
           .style("font-size", p_info[strip_text_size])
-          .text(function(d) { return d; })
-        // NOTE: there could be multiple strips per panel
-        // TODO: is there a better way to manage spacing?
           .attr("transform", trans_text + rot_text)
+          .each(function(d) { setMultilineText(d3.select(this), d); })
         ;
       }
       draw_strip([p_info.strips.top[layout_i]], "top");

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -198,25 +198,6 @@ var animint = function (to_select, json_file) {
     return {height: bbox.height, width: bbox.width};
   };
 
-  var measureMultilineText = function(pText, pFontSize, pAngle, pStyle) {
-    if (pText === undefined || pText === null || pText.length === 0) {
-      return {height: 0, width: 0};
-    }
-    var lines = pText.split("\n");
-    if (lines.length === 1) {
-      return measureText(pText, pFontSize, pAngle, pStyle);
-    }
-    var fontSize = parseFloat(pFontSize);
-    var sizes = lines.map(function(line) {
-      return measureText(line, pFontSize, pAngle, pStyle);
-    });
-    return {
-      height: (lines.length - 1) * fontSize * 1.2 +
-        d3.max(sizes, function(s) { return s.height; }),
-      width: d3.max(sizes, function(s) { return s.width; })
-    };
-  };
-
   var setMultilineText = function(textSelection, label) {
     var lines = label.split("\n");
     textSelection.text("");
@@ -226,6 +207,29 @@ var animint = function (to_select, json_file) {
         .attr("dy", i === 0 ? "0em" : "1.2em")
         .text(line);
     });
+  };
+
+  // Measure the same tspan layout that setMultilineText paints so
+  // reserved strip size matches browser em/pt metrics.
+  var measureMultilineText = function(pText, pFontSize, pAngle, pStyle) {
+    if (pText === undefined || pText === null || pText.length === 0) {
+      return {height: 0, width: 0};
+    }
+    var lines = pText.split("\n");
+    if (lines.length === 1) {
+      return measureText(pText, pFontSize, pAngle, pStyle);
+    }
+    if (pAngle === null || isNaN(pAngle)) pAngle = 0;
+    var container = element.append("svg");
+    var textSel = container.append("text")
+      .attr({x: -1000, y: -1000})
+      .attr("transform", "rotate(" + pAngle + ")")
+      .attr("style", pStyle)
+      .attr("font-size", pFontSize);
+    setMultilineText(textSel, pText);
+    var bbox = container.node().getBBox();
+    container.remove();
+    return {height: bbox.height, width: bbox.width};
   };
 
   var nest_by_group = d3.nest().key(function(d){ return d.group; });
@@ -698,21 +702,31 @@ var animint = function (to_select, json_file) {
         }
         var x, y, rotate, stripElement, strip_text_xy;
         if (side == "right") {
-          x = plotdim.xend;
-          y = (plotdim.ystart + plotdim.yend) / 2;
-          rotate = 90;
           stripElement = rightStrip;
           strip_text_xy = "y";
         }else{ //top
-          x = (plotdim.xstart + plotdim.xend) / 2;
-          y = plotdim.ystart;
-          rotate = 0;
           stripElement = topStrip;
           strip_text_xy = "x";
         }
+        var strip_text_size = "strip_text_"+strip_text_xy+"size";
+        var label = strip[0];
+        var firstLine = label.split("\n")[0];
+        var stripSize = side == "right"
+          ? strip_widths[layout_i]
+          : strip_heights[layout_i];
+        var oneLineSize = measureText(firstLine, p_info[strip_text_size]).height;
+        var extra = Math.max(0, stripSize - oneLineSize);
+        if (side == "right") {
+          x = plotdim.xend + extra;
+          y = (plotdim.ystart + plotdim.yend) / 2;
+          rotate = 90;
+        }else{ //top
+          x = (plotdim.xstart + plotdim.xend) / 2;
+          y = plotdim.ystart - extra;
+          rotate = 0;
+        }
         var trans_text = "translate(" + x + "," + y + ")";
         var rot_text = "rotate(" + rotate + ")";
-        var strip_text_size = "strip_text_"+strip_text_xy+"size";
         stripElement
           .selectAll("." + side + "Strips")
           .data(strip)

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -205,39 +205,6 @@ var animint = function (to_select, json_file) {
     return {height: bbox.height, width: bbox.width};
   };
 
-  var setMultilineText = function(textSelection, label) {
-    var lines = label.split("\n");
-    textSelection.text("");
-    lines.forEach(function(line, i) {
-      textSelection.append("tspan")
-        .attr("x", 0)
-        .attr("dy", i === 0 ? "0em" : "1.2em")
-        .text(line);
-    });
-  };
-
-  // Measure the same tspan layout that setMultilineText paints so
-  // reserved strip size matches browser em/pt metrics.
-  var measureMultilineText = function(pText, pFontSize, pAngle, pStyle) {
-    if (pText === undefined || pText === null || pText.length === 0) {
-      return {height: 0, width: 0};
-    }
-    var lines = pText.split("\n");
-    if (lines.length === 1) {
-      return measureText(pText, pFontSize, pAngle, pStyle);
-    }
-    if (pAngle === null || isNaN(pAngle)) pAngle = 0;
-    var container = element.append("svg");
-    var textSel = container.append("text")
-      .attr({x: -1000, y: -1000})
-      .attr("transform", "rotate(" + pAngle + ")")
-      .attr("style", pStyle)
-      .attr("font-size", pFontSize);
-    setMultilineText(textSel, pText);
-    var bbox = container.node().getBBox();
-    container.remove();
-    return {height: bbox.height, width: bbox.width};
-  };
 // Set multi-line text on SVG text elements.
 // Converts <br/> tags to <tspan> elements for proper SVG rendering.
 var setMultilineText = function(textElement, text) {
@@ -531,10 +498,10 @@ var setMultilineText = function(textElement, text) {
     plotdim.margin = margin;
     
     var strip_heights = p_info.strips.top.map(function(entry){ 
-      return measureMultilineText(entry, p_info.strip_text_xsize).height;
+      return measureText(entry, p_info.strip_text_xsize).height;
     });
     var strip_widths = p_info.strips.right.map(function(entry){ 
-      return measureMultilineText(entry, p_info.strip_text_ysize).height; 
+      return measureText(entry, p_info.strip_text_ysize).height; 
     });
 
     // compute the number of x/y axes, max strip height per row, and
@@ -758,7 +725,7 @@ var setMultilineText = function(textElement, text) {
         }
         var strip_text_size = "strip_text_"+strip_text_xy+"size";
         var label = strip[0];
-        var firstLine = label.split("\n")[0];
+        var firstLine = label.split("<br/>")[0];
         var stripSize = side == "right"
           ? strip_widths[layout_i]
           : strip_heights[layout_i];

--- a/tests/testthat/test-compiler-ghpages.R
+++ b/tests/testthat/test-compiler-ghpages.R
@@ -39,6 +39,10 @@ expect_no_Capture <- function(L){
 ## see how to set that up on your local computer, or on github
 ## actions.
 reset_test_repo <- function(){
+  github_pat <- Sys.getenv("GITHUB_PAT", unset = Sys.getenv("GITHUB_PAT_GITHUB_COM", unset = ""))
+  if (identical(github_pat, "")) {
+    testthat::skip("Skipping GitHub Pages integration tests: no GitHub token available")
+  }
   ## https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#delete-a-repository says The fine-grained token must have the following permission set: "Administration" repository permissions (write) gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/OWNER/REPO
   tryCatch({
     gh::gh(sprintf("DELETE /repos/animint-test/%s", test_repo_name))
@@ -48,7 +52,14 @@ reset_test_repo <- function(){
     ##Error in gh::gh(DELETE .../REPO): GitHub API error (404): Not Found
   })
   ## https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-an-organization-repository says The fine-grained token must have the following permission set: "Administration" repository permissions (write)
-  gh::gh("POST /orgs/animint-test/repos", name = test_repo_name)
+  tryCatch({
+    gh::gh("POST /orgs/animint-test/repos", name = test_repo_name)
+  }, error = function(e) {
+    testthat::skip(sprintf(
+      "Skipping GitHub Pages integration tests: unable to create test repository (%s)",
+      conditionMessage(e)
+    ))
+  })
   Sys.sleep(3)
 }
 test_that("animint2pages(chromote_sleep_seconds=3) creates Capture.PNG", {

--- a/tests/testthat/test-compiler-ghpages.R
+++ b/tests/testthat/test-compiler-ghpages.R
@@ -39,10 +39,6 @@ expect_no_Capture <- function(L){
 ## see how to set that up on your local computer, or on github
 ## actions.
 reset_test_repo <- function(){
-  github_pat <- Sys.getenv("GITHUB_PAT", unset = Sys.getenv("GITHUB_PAT_GITHUB_COM", unset = ""))
-  if (identical(github_pat, "")) {
-    testthat::skip("Skipping GitHub Pages integration tests: no GitHub token available")
-  }
   ## https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#delete-a-repository says The fine-grained token must have the following permission set: "Administration" repository permissions (write) gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/OWNER/REPO
   tryCatch({
     gh::gh(sprintf("DELETE /repos/animint-test/%s", test_repo_name))
@@ -52,14 +48,7 @@ reset_test_repo <- function(){
     ##Error in gh::gh(DELETE .../REPO): GitHub API error (404): Not Found
   })
   ## https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-an-organization-repository says The fine-grained token must have the following permission set: "Administration" repository permissions (write)
-  tryCatch({
-    gh::gh("POST /orgs/animint-test/repos", name = test_repo_name)
-  }, error = function(e) {
-    testthat::skip(sprintf(
-      "Skipping GitHub Pages integration tests: unable to create test repository (%s)",
-      conditionMessage(e)
-    ))
-  })
+  gh::gh("POST /orgs/animint-test/repos", name = test_repo_name)
   Sys.sleep(3)
 }
 test_that("animint2pages(chromote_sleep_seconds=3) creates Capture.PNG", {

--- a/tests/testthat/test-renderer1-facet-multiline.R
+++ b/tests/testthat/test-renderer1-facet-multiline.R
@@ -1,0 +1,33 @@
+acontext("facet-multiline")
+
+get_strip_tspan_labels <- function(html, side) {
+  strip_class <- if (side == "right") "rightStrip" else "topStrip"
+  xpath <- sprintf("//g[@class='%s']//tspan", strip_class)
+  nodes <- getNodeSet(html, xpath)
+  as.character(sapply(nodes, xmlValue))
+}
+
+p <- ggplot(mtcars, aes(mpg, wt)) + geom_point(colour = "grey50", size = 4)
+
+multiGridViz <- list(multiGridPlot = p + facet_grid(cyl + am ~ ., labeller = label_both))
+multiWrapViz <- list(multiWrapPlot = p + facet_wrap(~cyl + am, labeller = label_both))
+
+# mtcars facet_grid(cyl + am ~ .): 3 cyl x 2 am = 6 panels; 2 strip lines each => 12 tspans
+test_that("facet_grid() multi-variable strip labels render on separate lines", {
+  info <- animint2HTML(multiGridViz)
+  labels <- get_strip_tspan_labels(info$html, "right")
+  expect_equal(length(labels), 12)
+  expect_equal(labels[1], "cyl: 4")
+  expect_equal(labels[2], "am: 0")
+  expect_equal(sum(grepl("; ", labels)), 0)
+})
+
+# mtcars facet_wrap(~cyl + am): 6 panels; 2 strip lines each => 12 tspans
+test_that("facet_wrap() multi-variable strip labels render on separate lines", {
+  info <- animint2HTML(multiWrapViz)
+  labels <- get_strip_tspan_labels(info$html, "top")
+  expect_equal(length(labels), 12)
+  expect_equal(labels[1], "cyl: 4")
+  expect_equal(labels[2], "am: 0")
+  expect_equal(sum(grepl(", ", labels)), 0)
+})

--- a/tests/testthat/test-renderer1-facet-multiline.R
+++ b/tests/testthat/test-renderer1-facet-multiline.R
@@ -7,9 +7,24 @@ get_strip_tspan_labels <- function(html, side) {
   as.character(sapply(nodes, xmlValue))
 }
 
+# positive = strip extends into panel past the shared edge
+strip_panel_intrusion <- function(strip_sel, panel_sel, side) {
+  strip_bbox <- get_element_bbox(strip_sel)
+  panel_bbox <- get_element_bbox(panel_sel)
+  expect_gt(strip_bbox$width, 0)
+  expect_gt(panel_bbox$width, 0)
+  if (side == "top") {
+    (strip_bbox$top + strip_bbox$height) - panel_bbox$top
+  } else {
+    (panel_bbox$left + panel_bbox$width) - strip_bbox$left
+  }
+}
+
 p <- ggplot(mtcars, aes(mpg, wt)) + geom_point(colour = "grey50", size = 4)
 
+singleGridViz <- list(singleGridPlot = p + facet_grid(cyl ~ ., labeller = label_both))
 multiGridViz <- list(multiGridPlot = p + facet_grid(cyl + am ~ ., labeller = label_both))
+singleWrapViz <- list(singleWrapPlot = p + facet_wrap(~cyl, labeller = label_both))
 multiWrapViz <- list(multiWrapPlot = p + facet_wrap(~cyl + am, labeller = label_both))
 
 # mtcars facet_grid(cyl + am ~ .): 3 cyl x 2 am = 6 panels; 2 strip lines each => 12 tspans
@@ -30,4 +45,34 @@ test_that("facet_wrap() multi-variable strip labels render on separate lines", {
   expect_equal(labels[1], "cyl: 4")
   expect_equal(labels[2], "am: 0")
   expect_equal(sum(grepl(", ", labels)), 0)
+})
+
+pixel_slack <- 1
+
+test_that("multiline top strips do not intrude more than single-line strips", {
+  animint2HTML(singleWrapViz)
+  single_overlap <- strip_panel_intrusion(
+    "#plot_singleWrapPlot .topStrip text",
+    "#plot_singleWrapPlot .bgr1 rect.background_rect",
+    "top")
+  animint2HTML(multiWrapViz)
+  multi_overlap <- strip_panel_intrusion(
+    "#plot_multiWrapPlot .topStrip text",
+    "#plot_multiWrapPlot .bgr1 rect.background_rect",
+    "top")
+  expect_lte(multi_overlap, single_overlap + pixel_slack)
+})
+
+test_that("multiline right strips do not intrude more than single-line strips", {
+  animint2HTML(singleGridViz)
+  single_overlap <- strip_panel_intrusion(
+    "#plot_singleGridPlot .rightStrip text",
+    "#plot_singleGridPlot .bgr1 rect.background_rect",
+    "right")
+  animint2HTML(multiGridViz)
+  multi_overlap <- strip_panel_intrusion(
+    "#plot_multiGridPlot .rightStrip text",
+    "#plot_multiGridPlot .bgr1 rect.background_rect",
+    "right")
+  expect_lte(multi_overlap, single_overlap + pixel_slack)
 })

--- a/tests/testthat/test-renderer1-facets-strips.R
+++ b/tests/testthat/test-renderer1-facets-strips.R
@@ -40,11 +40,11 @@ test_that("facet_grid() strip labels are placed correctly", {
 
 test_that("facet_wrap() strip labels are placed correctly", {
   info <- animint2HTML(wrapViz)
-  top <- getNodeSet(info$html, "//g[@class='topStrip']")
-  kids <- xmlChildren(top[[1]])
-  labs <- as.character(sapply(kids, xmlValue))
-  expect_equal(labs, c("4, 0", "4, 1", "6, 0", 
-                       "6, 1", "8, 0", "8, 1"))
+  nodes <- getNodeSet(info$html, "//g[@class='topStrip']//tspan")
+  labs <- as.character(sapply(nodes, xmlValue))
+  expect_equal(labs[1:2], c("4", "0"))
+  expect_equal(length(labs), 12)
+  expect_equal(sum(grepl(", ", labs)), 0)
 })
 
 test_that("strip pos sensible for wrap(nrow=1)", {


### PR DESCRIPTION
Fixes #262 — animint2 currently joins multi-variable facet strip labels  onto one line (`cyl: 4; am: 0`). This PR makes them render on separate lines like ggplot2 does.
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/f71983fc-944f-4dca-88f1-28d3c963aa58" />
##  Root cause

| Facet type | Bug location | Current join |
|---|---|---|
| `facet_grid` | `R/z_facets.R` `build_strip()` | `"; "` |
| `facet_wrap` | `R/z_facets.R` `getStrips.wrap()` | `", "` |

`draw_strip()` in `animint.js` renders one flat `<text>` node — no `<tspan>`  support today.

## Two-commit structure

**Commit 1 (this commit) - failing test only**
- Adds `test-renderer1-facet-multiline.R`
- Checks 12 `<tspan>` elements across 6 panels × 2 variables for both 
  `facet_grid` and `facet_wrap`
- Currently fails: `length(labels) == 0` (no tspans exist yet) 

**Commit 2 — implementation**
- `R/z_facets.R`: change `collapse = "; "` / `", "` -> `collapse = "\n"`
- `inst/htmljs/animint.js`: split on `\n`, render each line as `<tspan>`