### PR TITLE
Interactive stat_bin with showSelected (#158 PoC)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: animint2
 Title: Animated Interactive Grammar of Graphics
-Version: 2026.6.28
+Version: 2026.8.19
 URL: https://animint.github.io/animint2
 BugReports: https://github.com/animint/animint2/issues
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in version 2026.8.19 (PR#158 PoC)
+
+- `stat_bin` with `showSelected` now recomputes histogram counts in the browser after selection changes, while keeping panel bin boundaries fixed. Proof-of-concept for issue #158. Thanks @ANAMASGARD.
+
 # Changes in version 2026.6.28 (PR#328)
 
 - New tooltipID(), mouseMoved(), mousePressed(), mouseReleased() helper functions in tests/testthat/helper-functions.R for simulating mouse events and checking tooltip elements in renderer tests.

--- a/R/geom-.r
+++ b/R/geom-.r
@@ -314,8 +314,14 @@ Geom <- gganimintproto("Geom",
     ## sense with clickSelects/showSelected, since two
     ## clickSelects/showSelected values may show up in the same bin.
     stat.type <- class(l$stat)[[1]]
-    checkForNonIdentityAndSS(stat.type, has.show, is.show, l,
-                            g$classed, names(g.data), names(g$aes))
+    js_stat_bin <- identical(l$js_stat, "bin")
+    if(!(js_stat_bin && stat.type == "StatBin")){
+      checkForNonIdentityAndSS(stat.type, has.show, is.show, l,
+                              g$classed, names(g.data), names(g$aes))
+    }
+    if(js_stat_bin){
+      g$js_stat <- "bin"
+    }
 
     ## Warn if non-identity position is used with animint aes.
     position.type <- class(l$position)[[1]]
@@ -331,9 +337,13 @@ Geom <- gganimintproto("Geom",
     ## special cases of basic geoms. In ggplot2, this processing is done
     ## in the draw method of the geoms.
 
-    processed_values <- l$geom$pre_process(g, g.data, ranges)
-    g <- processed_values$g
-    g.data <- processed_values$g.data
+    if(js_stat_bin){
+      g$geom <- "rect"
+    }else{
+      processed_values <- l$geom$pre_process(g, g.data, ranges)
+      g <- processed_values$g
+      g.data <- processed_values$g.data
+    }
     ## Check g.data for color/fill - convert to hexadecimal so JS can parse correctly.
     for(color.var in c("colour", "color", "fill", "colour_off", "color_off", "fill_off")){
       if(color.var %in% names(g.data)){

--- a/R/plot-build.r
+++ b/R/plot-build.r
@@ -296,3 +296,79 @@ ggplot_gtable <- function(data) {
 ggplotGrob <- function(x) {
   ggplot_gtable(ggplot_build(x))
 }
+
+layer_has_showSelected <- function(l) {
+  ep <- l$extra_params
+  is.character(ep$showSelected) && length(ep$showSelected) > 0
+}
+
+validate_js_stat_bin_params <- function(l) {
+  params <- l$stat_params
+  if(is.null(params$binwidth)){
+    stop("JS stat_bin requires binwidth to be set explicitly.", call.=FALSE)
+  }
+  if(!is.null(params$bins)){
+    stop("JS stat_bin does not support bins=; use binwidth= instead.", call.=FALSE)
+  }
+  if(!is.null(params$boundary)){
+    stop("JS stat_bin does not support boundary=.", call.=FALSE)
+  }
+  if(!is.null(params$center)){
+    stop("JS stat_bin does not support center=.", call.=FALSE)
+  }
+  if(isTRUE(params$pad)){
+    stop("JS stat_bin does not support pad=TRUE.", call.=FALSE)
+  }
+  closed <- params$closed
+  if(!is.null(closed) && !identical(closed, "right")){
+    stop("JS stat_bin only supports closed=\"right\".", call.=FALSE)
+  }
+  if(class(l$position)[[1]] != "PositionIdentity"){
+    stop("JS stat_bin requires position=identity.", call.=FALSE)
+  }
+}
+
+get_pre_stat_layer_data <- function(plot) {
+  plot <- a_plot_clone(plot)
+  if(length(plot$layers) == 0) {
+    plot <- plot + geom_blank()
+  }
+  layers <- plot$layers
+  layer_data <- lapply(layers, function(y) y$layer_data(plot$data))
+  scales <- plot$scales
+  panel <- new_panel()
+  panel <- g_train_layout(panel, plot$facet, layer_data, plot$data)
+  data <- map_layout(panel, plot$facet, layer_data)
+  by_layer <- function(f) {
+    out <- vector("list", length(data))
+    for(i in seq_along(data)) {
+      out[[i]] <- f(l = layers[[i]], d = data[[i]])
+    }
+    out
+  }
+  data <- by_layer(function(l, d) l$compute_aesthetics(d, plot))
+  data <- lapply(data, scales_transform_df, scales = scales)
+  scale_x <- function() scales$get_scales("x")
+  scale_y <- function() scales$get_scales("y")
+  panel <- train_position(panel, data, scale_x(), scale_y())
+  map_position(panel, data, scale_x(), scale_y())
+}
+
+js_stat_bin_x_breaks <- function(built, binwidth) {
+  layout <- built$panel$layout
+  breaks_list <- list()
+  for(panel_i in layout$PANEL) {
+    scales <- panel_scales(built$panel, panel_i)
+    bins <- bin_breaks_width(scales$x$dimension(), binwidth)
+    breaks_list[[as.character(panel_i)]] <- bins$breaks
+  }
+  breaks_list
+}
+
+js_stat_bin_all_panels <- function(df, panel_ids) {
+  do.call(rbind, lapply(panel_ids, function(panel_i) {
+    out <- df
+    out$PANEL <- panel_i
+    out
+  }))
+}

--- a/R/z_animint.R
+++ b/R/z_animint.R
@@ -373,7 +373,24 @@ animint2dir <- function
     ggplot.info <- ggplot.list[[p.name]]
     for(layer.i in seq_along(ggplot.info$ggplot$layers)){
       L <- ggplot.info$ggplot$layers[[layer.i]]
-      df <- ggplot.info$built$data[[layer.i]]
+      if(identical(class(L$stat)[[1]], "StatBin") && layer_has_showSelected(L)){
+        validate_js_stat_bin_params(L)
+        pre_stat <- get_pre_stat_layer_data(ggplot.info$ggplot)
+        df <- pre_stat[[layer.i]]
+        npscales <- ggplot.info$ggplot$scales$non_position_scales()
+        if(npscales$n() > 0) {
+          scales_train_df(df, scales = npscales)
+          df <- scales_map_df(df, scales = npscales)
+        }
+        panel_ids <- ggplot.info$built$panel$layout$PANEL
+        df <- js_stat_bin_all_panels(df, panel_ids)
+        L$js_stat <- "bin"
+        L$stat_params$x_breaks <- js_stat_bin_x_breaks(
+          ggplot.info$built, L$stat_params$binwidth)
+        ggplot.info$ggplot$layers[[layer.i]] <- L
+      }else{
+        df <- ggplot.info$built$data[[layer.i]]
+      }
       ## Data now contains columns with fill, alpha, colour etc.
       ## Remove from data if they have a single unique value and
       ## are NOT used in mapping to reduce tsv file size

--- a/R/z_knitr.R
+++ b/R/z_knitr.R
@@ -23,6 +23,7 @@ knit_print.animint <- function(x, options, ...) {
   if (length(knitr::knit_meta(class = "animint", clean = FALSE)) == 0) {
     res <- sprintf('
 <script type="text/javascript" src="%s/vendor/d3.v3.js"></script>
+<script type="text/javascript" src="%s/stat-bin.js"></script>
 <script type="text/javascript" src="%s/animint.js"></script>
 <script type="text/javascript" src="%s/vendor/quadprog.js"></script>
 <link rel="stylesheet" type="text/css" href="%s/animint.css" />
@@ -31,7 +32,7 @@ knit_print.animint <- function(x, options, ...) {
 <link rel="stylesheet" type="text/css" href="%s/vendor/selectize.css" />
 <script type="text/javascript" src="%s/vendor/driver.js.iife.js"></script>
 <link rel="stylesheet" href="%s/vendor/driver.css" />
-%s', viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, res)
+%s', viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, viz_id, res)
   }
   knitr::asis_output(res, meta = list(animint = structure("", class = "animint")))
 }
@@ -101,7 +102,7 @@ html_dependency_animint <- function() {
   htmltools::htmlDependency(name = "animint",
                  version = packageVersion("animint2"),
                  src = system.file("htmljs", package = "animint2"),
-                 script = "animint.js")
+                 script = c("stat-bin.js", "animint.js"))
 }
 
 html_dependency_shinyAnimint <- function() {

--- a/inst/htmljs/animint.js
+++ b/inst/htmljs/animint.js
@@ -1169,6 +1169,9 @@ var animint = function (to_select, json_file) {
         data = data.concat(some_data);
       }
     });
+    if (g_info.js_stat === "bin") {
+        data = compute_stat_bin(data, g_info.params, PANEL);
+    }
     var aes = g_info.aes;
     var toXY = function (xy, a) {
       return function (d) {

--- a/inst/htmljs/index.html
+++ b/inst/htmljs/index.html
@@ -4,6 +4,7 @@
     <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <title>Interactive animation</title>
     <script type="text/javascript" src="vendor/d3.v3.js"></script>
+    <script type="text/javascript" src="stat-bin.js"></script>
     <script type="text/javascript" src="animint.js"></script>
     <script type="text/javascript" src="vendor/quadprog.js"></script>
     <link rel="stylesheet" type="text/css" href="animint.css" />

--- a/inst/htmljs/stat-bin.js
+++ b/inst/htmljs/stat-bin.js
@@ -1,0 +1,71 @@
+function bin_index_for_stat_bin(x, breaks) {
+        var i, left, right;
+        for (i = 0; i < breaks.length - 1; i++) {
+                left = breaks[i];
+                right = breaks[i + 1];
+                if (i === 0) {
+                        if (left <= x && x <= right) {
+                                return i;
+                        }
+                } else if (left < x && x <= right) {
+                        return i;
+                }
+        }
+        return -1;
+}
+
+function count_into_breaks(rows, breaks) {
+        var n_bins = breaks.length - 1;
+        var counts = [];
+        var i, row_i, bin_i, x_val;
+        for (i = 0; i < n_bins; i++) {
+                counts[i] = 0;
+        }
+        for (row_i = 0; row_i < rows.length; row_i++) {
+                x_val = rows[row_i].x;
+                if (x_val === null || isNaN(x_val)) {
+                        continue;
+                }
+                bin_i = bin_index_for_stat_bin(Number(x_val), breaks);
+                if (0 <= bin_i) {
+                        counts[bin_i] += 1;
+                }
+        }
+        return counts;
+}
+
+function compute_stat_bin(data, params, PANEL) {
+        var breaks, panel_key, groups, out, group_i, group_rows;
+        var fill_val, counts, bin_i;
+        if (!Array.isArray(data) || data.length === 0) {
+                return [];
+        }
+        var panel_index = Number(PANEL) - 1;
+        breaks = params.x_breaks[panel_index];
+        if ((!breaks || breaks.length < 2) && params.x_breaks.hasOwnProperty(String(PANEL))) {
+                breaks = params.x_breaks[String(PANEL)];
+        }
+        if (!breaks || breaks.length < 2) {
+                return [];
+        }
+        groups = d3.nest().key(function(d) {
+                return d.group;
+        }).sortKeys(d3.ascending).entries(data);
+        out = [];
+        for (group_i = 0; group_i < groups.length; group_i++) {
+                group_rows = groups[group_i].values;
+                fill_val = group_rows[0].fill;
+                counts = count_into_breaks(group_rows, breaks);
+                for (bin_i = 0; bin_i < counts.length; bin_i++) {
+                        out.push({
+                                xmin: breaks[bin_i],
+                                xmax: breaks[bin_i + 1],
+                                ymin: 0,
+                                ymax: counts[bin_i],
+                                fill: fill_val,
+                                group: groups[group_i].key
+                        });
+                }
+        }
+        return out;
+}

--- a/tests/testthat/helper-HTML.R
+++ b/tests/testthat/helper-HTML.R
@@ -5,6 +5,7 @@ animint2HTML <- function(plotList) {
   unlink("animint-htmltest", recursive=TRUE)
   res <- animint2dir(plotList, out.dir = "animint-htmltest",
                      open.browser = FALSE)
+  snapshot_js_coverage()
   remDr$refresh()
   Sys.sleep(2)
   res$html <- getHTML()
@@ -112,34 +113,48 @@ getClassBound <- function(geom.class, position){
 }
 
 # JS Coverage collection functions
+append_js_coverage <- function() {
+  cov <- remDr$Profiler$takePreciseCoverage()
+  remDr$js_coverage_snapshots <- c(remDr$js_coverage_snapshots, list(cov$result))
+}
+
+snapshot_js_coverage <- function() {
+  if(!identical(Sys.getenv("TEST_SUITE"), "JS_coverage")) return(invisible(NULL))
+  if(is.null(remDr$js_coverage_snapshots)) return(invisible(NULL))
+  tryCatch({
+    append_js_coverage()
+    remDr$Profiler$startPreciseCoverage(callCount = TRUE, detailed = TRUE)
+  }, error = function(e) {
+    warning(sprintf("Failed to snapshot JS coverage: %s", e$message))
+  })
+  invisible(NULL)
+}
+
 start_js_coverage <- function() {
   tryCatch({
     remDr$Profiler$enable()
-    remDr$Profiler$startPreciseCoverage(
-      callCount = TRUE,
-      detailed = TRUE
-    )
+    remDr$js_coverage_snapshots <- list()
+    remDr$Profiler$startPreciseCoverage(callCount = TRUE, detailed = TRUE)
     TRUE
   }, error = function(e) {
-    warning("Failed to start JS coverage: ", e$message)
+    warning(sprintf("Failed to start JS coverage: %s", e$message))
     FALSE
   })
 }
 
 stop_js_coverage <- function() {
   tryCatch({
-    cov <- remDr$Profiler$takePreciseCoverage()
+    append_js_coverage()
     outfile <- "js-coverage.json"
-    # Ensure the format matches what v8-to-istanbul expects
     coverage_data <- list(
-      result = cov$result,
+      result = do.call(c, remDr$js_coverage_snapshots),
       url = "http://localhost:4848/animint-htmltest/animint.js"
     )
     jsonlite::write_json(coverage_data, outfile, auto_unbox = TRUE)
-    message("JS coverage saved to ", normalizePath(outfile))
+    message(sprintf("JS coverage saved to %s", normalizePath(outfile)))
     TRUE
   }, error = function(e) {
-    warning("Failed to save JS coverage: ", e$message)
+    warning(sprintf("Failed to save JS coverage: %s", e$message))
     FALSE
   })
 }

--- a/tests/testthat/test-renderer3-stat-bin-showSelected.R
+++ b/tests/testthat/test-renderer3-stat-bin-showSelected.R
@@ -12,7 +12,7 @@ df <- rbind(
 )
 
 rect_xpath <- function(panel=1){
-  sprintf('//g[@class="PANEL%d"]//g[contains(@class,"geom1_bar_plot")]//rect', panel)
+  sprintf('//g[contains(@class,"geom1_bar_plot")]//g[@class="PANEL%d"]//rect', panel)
 }
 
 get_rect_heights <- function(html, panel=1){
@@ -22,7 +22,7 @@ get_rect_heights <- function(html, panel=1){
 max_height_by_fill <- function(html, panel=1){
   fills <- getStyleValue(html, rect_xpath(panel), "fill")
   heights <- get_rect_heights(html, panel)
-  stats::tapply(heights, fills, max)
+  tapply(heights, fills, max)
 }
 
 get_rect_x_width <- function(html, panel=1){
@@ -33,10 +33,11 @@ get_rect_x_width <- function(html, panel=1){
 }
 
 select_facet <- function(facet){
-  runtime_evaluate(script='document.getElementsByClassName("facet_variable_selector_widget")[0].getElementsByClassName("selectize-input")[0].dispatchEvent(new CustomEvent("click"));')
-  sendKey("Backspace")
-  remDr$Input$insertText(text=as.character(facet))
-  sendKey("Enter")
+  facet_id <- sprintf("facet___%s", facet)
+  runtime_evaluate(script=sprintf(
+    '$("select.facet_variable_input")[0].selectize.setValue("%s");',
+    facet_id
+  ))
   Sys.sleep(0.5)
 }
 
@@ -60,9 +61,8 @@ stat_bin_showSelected_viz <- function(){
 }
 
 test_that("stat_bin with showSelected recalculates after selection", {
-  info <- NULL
   expect_no_warning({
-    info <<- animint2HTML(stat_bin_showSelected_viz())
+    info <- animint2HTML(stat_bin_showSelected_viz())
   })
   initial_heights <- max_height_by_fill(info$html, 1)
   expect_length(initial_heights, 2)

--- a/tests/testthat/test-renderer3-stat-bin-showSelected.R
+++ b/tests/testthat/test-renderer3-stat-bin-showSelected.R
@@ -1,0 +1,80 @@
+acontext("stat bin showSelected")
+
+make <- function(count, stack, facet){
+  data.frame(count=count, row=seq_along(count), stack=stack, facet=facet)
+}
+
+df <- rbind(
+  make(c(1, 1, 1, 2), 1, 1),
+  make(c(3, 3, 4, 5), 2, 1),
+  make(c(1, 2, 2, 3), 1, 2),
+  make(c(3, 4, 4, 4), 2, 2)
+)
+
+rect_xpath <- function(panel=1){
+  sprintf('//g[@class="PANEL%d"]//g[contains(@class,"geom1_bar_plot")]//rect', panel)
+}
+
+get_rect_heights <- function(html, panel=1){
+  as.numeric(getPropertyValue(html, rect_xpath(panel), "height"))
+}
+
+max_height_by_fill <- function(html, panel=1){
+  fills <- getStyleValue(html, rect_xpath(panel), "fill")
+  heights <- get_rect_heights(html, panel)
+  stats::tapply(heights, fills, max)
+}
+
+get_rect_x_width <- function(html, panel=1){
+  list(
+    x=as.numeric(getPropertyValue(html, rect_xpath(panel), "x")),
+    width=as.numeric(getPropertyValue(html, rect_xpath(panel), "width"))
+  )
+}
+
+select_facet <- function(facet){
+  runtime_evaluate(script='document.getElementsByClassName("facet_variable_selector_widget")[0].getElementsByClassName("selectize-input")[0].dispatchEvent(new CustomEvent("click"));')
+  sendKey("Backspace")
+  remDr$Input$insertText(text=as.character(facet))
+  sendKey("Enter")
+  Sys.sleep(0.5)
+}
+
+stat_bin_showSelected_viz <- function(){
+  list(
+    plot=ggplot() +
+      theme_bw() +
+      theme(panel.margin=grid::unit(0, "lines")) +
+      geom_histogram(
+        aes(count, group=stack, fill=stack),
+        showSelected="facet",
+        binwidth=1,
+        data=df,
+        stat="bin",
+        position="identity"
+      ) +
+      facet_grid(facet~.),
+    first=list(facet=1),
+    selector.types=list(facet="single")
+  )
+}
+
+test_that("stat_bin with showSelected recalculates after selection", {
+  info <- NULL
+  expect_no_warning({
+    info <<- animint2HTML(stat_bin_showSelected_viz())
+  })
+  initial_heights <- max_height_by_fill(info$html, 1)
+  expect_length(initial_heights, 2)
+  expect_gt(length(get_rect_heights(info$html, 1)), 0)
+  initial_bounds <- get_rect_x_width(info$html, 1)
+  select_facet(2)
+  html_after <- getHTML()
+  selected_heights <- max_height_by_fill(html_after, 1)
+  expect_length(selected_heights, 2)
+  expect_gt(length(get_rect_heights(html_after, 1)), 0)
+  expect_identical(order(initial_heights), rev(order(selected_heights)))
+  selected_bounds <- get_rect_x_width(html_after, 1)
+  expect_equal(sort(initial_bounds$x), sort(selected_bounds$x))
+  expect_equal(sort(initial_bounds$width), sort(selected_bounds$width))
+})

--- a/tests/testthat/test-renderer3-stat-bin.R
+++ b/tests/testthat/test-renderer3-stat-bin.R
@@ -15,7 +15,7 @@ df <- rbind(
   make(4, 1, 2)
 )
 
-test_that("error for stat=bin and showSelected", {
+test_that("stat=bin with showSelected compiles and renders", {
   gg <- ggplot() +
     theme_bw()+
     theme(panel.margin=grid::unit(0, "lines"))+
@@ -26,14 +26,18 @@ test_that("error for stat=bin and showSelected", {
       data = df,
       stat = "bin",
       position="identity"
-    )
-  gg+facet_grid(facet~.)
-  complicated <- list(
-    plot = gg
-  )
-  expect_error({
-    animint2HTML(complicated)
-  }, "showSelected does not work with StatBin, problem: geom1_bar_plot")
+    )+
+    facet_grid(facet~.)
+  complicated <- list(plot = gg)
+  expect_no_warning({
+    info <- animint2HTML(complicated)
+  })
+  for(panel in 1:2){
+    xpath <- sprintf('//g[@class="PANEL%d"]//rect', panel)
+    style.vec <- getStyleValue(info$html, xpath, "fill")
+    fill.counts <- table(style.vec)
+    expect_equal(length(fill.counts), 2)
+  }
 })
 
 test_that("no warning for stat=bin without showSelected", {

--- a/v8-to-istanbul.js
+++ b/v8-to-istanbul.js
@@ -2,68 +2,81 @@ const fs = require('fs');
 const path = require('path');
 const v8toIstanbul = require('v8-to-istanbul');
 
+function mergeHits(oldHits, newHits) {
+        var merged = Object.assign({}, oldHits);
+        var key, oldVal, newVal;
+        for (key in newHits) {
+                oldVal = merged[key];
+                newVal = newHits[key];
+                if (Array.isArray(newVal)) {
+                        merged[key] = newVal.map(function(count, i) {
+                                return Math.max(count, Array.isArray(oldVal) ? oldVal[i] || 0 : 0);
+                        });
+                } else {
+                        merged[key] = Math.max(oldVal || 0, newVal);
+                }
+        }
+        return merged;
+}
+
+function mergeFileCoverage(existing, incoming) {
+        var pathKey, next, prev;
+        for (pathKey in incoming) {
+                next = incoming[pathKey];
+                prev = existing[pathKey];
+                if (prev) {
+                        prev.s = mergeHits(prev.s, next.s);
+                        prev.f = mergeHits(prev.f, next.f);
+                        prev.b = mergeHits(prev.b, next.b);
+                } else {
+                        existing[pathKey] = next;
+                }
+        }
+}
+
 async function convertToIstanbul() {
-  try {
-    // Path configuration
-    const coverageJsonPath = path.join('tests', 'testthat', 'js-coverage.json');
-    const outputIstanbulPath = 'coverage-istanbul.json';
-    const baseDir = path.join(__dirname, 'inst', 'htmljs');
-
-    console.log(`Reading coverage data from: ${coverageJsonPath}`);
-    console.log(`Looking for source files in: ${baseDir}`);
-
-    // Check if input file exists
-    if (!fs.existsSync(coverageJsonPath)) {
-      console.error(`Error: Coverage file not found at ${coverageJsonPath}`);
-      process.exit(1);
-    }
-    const rawCoverage = JSON.parse(fs.readFileSync(coverageJsonPath, 'utf8'));
-    const istanbulCoverage = {};
-    // Process each file's coverage
-    for (const scriptCoverage of rawCoverage.result) {
-      const url = scriptCoverage.url;
-      // Skip empty URLs
-      if (!url) continue;
-      // Extract the relative file path from the URL
-      const filePath = url.replace(/^http:\/\/localhost:\d+\/animint-htmltest\//, '');
-      if (filePath.startsWith('vendor/')) {
-        //Skip files under vendor/
-        continue;
-      }
-      const fullPath = path.join(baseDir, filePath);
-      // Skip if path is empty or file doesn't exist
-      if (!filePath || !fs.existsSync(fullPath)) {
-        continue;
-      }
-      try {
-        const scriptSource = fs.readFileSync(fullPath, 'utf8');
-        // Create converter for this file
-        const converter = v8toIstanbul(fullPath, 0, {
-          source: scriptSource
-        });
-        await converter.load();
-        converter.applyCoverage(scriptCoverage.functions);
-        // Get Istanbul coverage data for this file and merge it
-        const fileCoverage = converter.toIstanbul();
-        Object.assign(istanbulCoverage, fileCoverage);
-        console.log(`Processed coverage for: ${filePath}`);
-      } catch (err) {
-        console.error(`Error processing ${filePath}:`, err.message);
-      }
-    }
-    // Save Istanbul coverage data
-    if (Object.keys(istanbulCoverage).length > 0) {
-      fs.writeFileSync(outputIstanbulPath, JSON.stringify(istanbulCoverage, null, 2));
-      console.log(`Successfully converted coverage to ${outputIstanbulPath}`);
-
-    } else {
-      console.error('No valid coverage data was processed');
-      process.exit(1);
-    }
-  } catch (err) {
-    console.error('Error converting coverage:', err.message);
-    process.exit(1);
-  }
+        try {
+                const coverageJsonPath = path.join('tests', 'testthat', 'js-coverage.json');
+                const outputIstanbulPath = 'coverage-istanbul.json';
+                const baseDir = path.join(__dirname, 'inst', 'htmljs');
+                console.log(`Reading coverage data from: ${coverageJsonPath}`);
+                console.log(`Looking for source files in: ${baseDir}`);
+                if (!fs.existsSync(coverageJsonPath)) {
+                        console.error(`Error: Coverage file not found at ${coverageJsonPath}`);
+                        process.exit(1);
+                }
+                const rawCoverage = JSON.parse(fs.readFileSync(coverageJsonPath, 'utf8'));
+                const istanbulCoverage = {};
+                for (const scriptCoverage of rawCoverage.result) {
+                        const url = scriptCoverage.url;
+                        if (!url) continue;
+                        const filePath = url.replace(/^http:\/\/localhost:\d+\/animint-htmltest\//, '');
+                        if (filePath.startsWith('vendor/')) continue;
+                        const fullPath = path.join(baseDir, filePath);
+                        if (!filePath || !fs.existsSync(fullPath)) continue;
+                        try {
+                                const converter = v8toIstanbul(fullPath, 0, {
+                                        source: fs.readFileSync(fullPath, 'utf8')
+                                });
+                                await converter.load();
+                                converter.applyCoverage(scriptCoverage.functions);
+                                mergeFileCoverage(istanbulCoverage, converter.toIstanbul());
+                                console.log(`Processed coverage for: ${filePath}`);
+                        } catch (err) {
+                                console.error(`Error processing ${filePath}:`, err.message);
+                        }
+                }
+                if (Object.keys(istanbulCoverage).length > 0) {
+                        fs.writeFileSync(outputIstanbulPath, JSON.stringify(istanbulCoverage, null, 2));
+                        console.log(`Successfully converted coverage to ${outputIstanbulPath}`);
+                } else {
+                        console.error('No valid coverage data was processed');
+                        process.exit(1);
+                }
+        } catch (err) {
+                console.error('Error converting coverage:', err.message);
+                process.exit(1);
+        }
 }
 
 convertToIstanbul();


### PR DESCRIPTION
## Summary
This PR starts work on #158: making `stat_bin` work with `showSelected` so histograms update when the user changes selection.

## What  in Commit 1

Added `tests/testthat/test-renderer3-stat-bin-showSelected.R`.

The test checks that a faceted histogram with `showSelected="facet"`:
- compiles without the current StatBin guard warning
- renders in the browser
- recalculates counts when facet selection changes
- keeps bin positions stable

## Why

Issue #158 asks whether stats should move out of compile-time processing. This PR defines the expected behavior for a small `stat_bin + showSelected` proof-of-concept before implementation.

## How the fix will work (Commit 2 )

1. R exports pre-stat data, `showSelected` columns, and panel `x_breaks`.
2. JS filters by selection, recomputes bin counts, then draws bars.

Selection changes counts, not the bin grid.
<img width="618" height="1032" alt="Screenshot From 2026-08-12 21-06-44" src="https://github.com/user-attachments/assets/e23c198f-bcc3-4ebf-bb77-23bdf4b768f3" />


##  Local run shows expected failure on master
<img width="1907" height="802" alt="image" src="https://github.com/user-attachments/assets/f1665475-fc7c-4e9b-817d-a0f3875008ee" />
