### PR TITLE
Fix false Codecov project coverage drops by uploading R and JS reports together

### DIFF
--- a/.github/scripts/save-r-coverage.R
+++ b/.github/scripts/save-r-coverage.R
@@ -1,0 +1,23 @@
+# Generate R coverage as Cobertura XML for a later combined Codecov upload.
+# Path cleanup uses gsub() so Codecov can match files in this repository.
+if (!requireNamespace("covr", quietly = TRUE)) {
+  stop("covr is required to generate R coverage")
+}
+
+cov <- covr::package_coverage(
+  quiet = FALSE,
+  type = "tests",
+  test_files = "tests/testthat.R"
+)
+print(cov)
+
+out_file <- "r-coverage.xml"
+covr::to_cobertura(cov, filename = out_file)
+
+root <- normalizePath(getwd(), winslash = "/", mustWork = TRUE)
+xml <- paste(readLines(out_file, warn = FALSE), collapse = "\n")
+xml <- gsub("\\\\", "/", xml)
+xml <- gsub(root, ".", xml, fixed = TRUE)
+writeLines(xml, out_file)
+
+message("Wrote ", out_file)

--- a/.github/scripts/save-r-coverage.R
+++ b/.github/scripts/save-r-coverage.R
@@ -1,5 +1,5 @@
-# Generate R coverage as Cobertura XML for a later combined Codecov upload.
-# Path cleanup uses gsub() so Codecov can match files in this repository.
+# Generate the same Rlang JSON that covr::codecov() used to POST, then save it
+# as an artifact for a later combined Codecov upload.
 if (!requireNamespace("covr", quietly = TRUE)) {
   stop("covr is required to generate R coverage")
 }
@@ -11,13 +11,8 @@ cov <- covr::package_coverage(
 )
 print(cov)
 
-out_file <- "r-coverage.xml"
-covr::to_cobertura(cov, filename = out_file)
-
-root <- normalizePath(getwd(), winslash = "/", mustWork = TRUE)
-xml <- paste(readLines(out_file, warn = FALSE), collapse = "\n")
-xml <- gsub("\\\\", "/", xml)
-xml <- gsub(root, ".", xml, fixed = TRUE)
-writeLines(xml, out_file)
+out_file <- "r-coverage.json"
+# to_codecov() is the JSON body that covr::codecov() uploads.
+writeLines(covr:::to_codecov(cov), out_file)
 
 message("Wrote ", out_file)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,32 +6,28 @@ on:
     branches: [main, master]
 
 jobs:
-  R-CMD-check:
+  coverage-tests:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        test-suite: [ R_coverage, JS_coverage, CRAN ]
+        test-suite: [ R_coverage, JS_coverage ]
 
     name: ${{ matrix.test-suite }}
-    env: 
+    env:
       TEST_SUITE: ${{ matrix.test-suite }}
       GITHUB_PAT: ${{ secrets.PAT_GITHUB }}
       GH_ACTION: "ENABLED"
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - name: install and update texlive
-        run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt update -y -qq
-      - run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt install tidy texlive texlive-fonts-extra -y
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
 
       - name: install package
         run: R CMD INSTALL .
 
-      - name: git config user.name 
+      - name: git config user.name
         run: git config --global user.name "GitHub Actions"
 
       - name: git config user.email
@@ -42,44 +38,112 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-        
+
       - name: Install Node.js dependencies
         if: matrix.test-suite == 'JS_coverage'
         run: |
           npm install v8-to-istanbul
           echo "Node modules installed"
-      
-      - name: run tests
+
+      - name: Run R tests and save coverage
+        if: matrix.test-suite == 'R_coverage'
+        run: Rscript .github/scripts/save-r-coverage.R
+
+      - name: Upload R coverage artifact
+        if: matrix.test-suite == 'R_coverage'
+        uses: actions/upload-artifact@v4
+        with:
+          name: r-coverage
+          path: r-coverage.xml
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Run JS tests
+        if: matrix.test-suite == 'JS_coverage'
         run: |
-          if [ "$TEST_SUITE" == "CRAN" ]; then
-            bash build.sh
-          elif [ "$TEST_SUITE" == "JS_coverage" ]; then
-            echo "Running testthat with JS coverage collection..."
-            Rscript -e "source('tests/testthat.R', chdir = TRUE)"
-          else
-            echo "Running testthat with R coverage collection..."
-            Rscript -e 'covr::codecov(quiet = FALSE, type = "tests", test_files = "tests/testthat.R", flags = "r")'
-          fi
+          echo "Running testthat with JS coverage collection..."
+          Rscript -e "source('tests/testthat.R', chdir = TRUE)"
 
       - name: Convert JS coverage to Istanbul format
         if: matrix.test-suite == 'JS_coverage'
         run: |
           if [ -f "tests/testthat/js-coverage.json" ]; then
-            echo "Converting JS coverage to LCOV format..."
+            echo "Converting JS coverage to Istanbul format..."
             node v8-to-istanbul.js
           else
             echo "No JS coverage file found"
             exit 1
           fi
 
-      - name: Upload JS coverage to Codecov
+      - name: Upload JS coverage artifact
         if: matrix.test-suite == 'JS_coverage'
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-coverage
+          path: coverage-istanbul.json
+          if-no-files-found: error
+          retention-days: 1
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    name: Upload combined coverage to Codecov
+    needs: coverage-tests
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download R coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: r-coverage
+          path: ./
+
+      - name: Download JS coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: js-coverage
+          path: ./
+
+      - name: Verify both coverage reports exist
         run: |
-          if [ -f "coverage-istanbul.json" ]; then
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            chmod +x codecov
-            ./codecov -f coverage-istanbul.json -t ${{ secrets.CODECOV_TOKEN }} --flags javascript
-          else
-            echo "No coverage file found"
-            exit 1
-          fi
+          test -f r-coverage.xml
+          test -f coverage-istanbul.json
+
+      - name: Upload R and JS coverage together
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: r-coverage.xml,coverage-istanbul.json
+          disable_search: true
+          fail_ci_if_error: true
+          verbose: true
+
+  CRAN:
+    runs-on: ubuntu-latest
+    name: CRAN
+    env:
+      TEST_SUITE: CRAN
+      GITHUB_PAT: ${{ secrets.PAT_GITHUB }}
+      GH_ACTION: "ENABLED"
+    steps:
+      - uses: actions/checkout@v4
+      - name: install and update texlive
+        run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt update -y -qq
+      - run: /usr/bin/sudo DEBIAN_FRONTEND=noninteractive apt install tidy texlive texlive-fonts-extra -y
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+
+      - name: install package
+        run: R CMD INSTALL .
+
+      - name: git config user.name
+        run: git config --global user.name "GitHub Actions"
+
+      - name: git config user.email
+        run: git config --global user.email toby.hocking@r-project.org
+
+      - name: run CRAN build
+        run: bash build.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -140,5 +140,8 @@ jobs:
       - name: run PDF renderer test
         run: Rscript -e 'testthat::test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'
 
+      - name: run PDF renderer test
+        run: Rscript -e 'testthat::test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'
+
       - name: run CRAN build
         run: bash build.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,6 +99,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: r-coverage
+          path: ./
+
+      - name: Download JS coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: js-coverage
+          path: ./
+
       - name: Verify both coverage reports exist
         run: |
           test -s r-coverage.json
@@ -136,9 +144,6 @@ jobs:
 
       - name: git config user.email
         run: git config --global user.email toby.hocking@r-project.org
-
-      - name: run PDF renderer test
-        run: Rscript -e 'testthat::test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'
 
       - name: run PDF renderer test
         run: Rscript -e 'testthat::test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,14 +99,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: r-coverage
-          path: ./
-
-      - name: Download JS coverage artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: js-coverage
-          path: ./
-
       - name: Verify both coverage reports exist
         run: |
           test -s r-coverage.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -146,7 +146,7 @@ jobs:
         run: git config --global user.email toby.hocking@r-project.org
 
       - name: run PDF renderer test
-        run: Rscript -e 'testthat::test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'
+        run: Rscript -e 'library(testthat); library(animint2); library(XML); test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'
 
       - name: run CRAN build
         run: bash build.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: r-coverage
-          path: r-coverage.xml
+          path: r-coverage.json
           if-no-files-found: error
           retention-days: 1
 
@@ -109,14 +109,14 @@ jobs:
 
       - name: Verify both coverage reports exist
         run: |
-          test -f r-coverage.xml
-          test -f coverage-istanbul.json
+          test -s r-coverage.json
+          test -s coverage-istanbul.json
 
       - name: Upload R and JS coverage together
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: r-coverage.xml,coverage-istanbul.json
+          files: r-coverage.json,coverage-istanbul.json
           disable_search: true
           fail_ci_if_error: true
           verbose: true
@@ -144,6 +144,9 @@ jobs:
 
       - name: git config user.email
         run: git config --global user.email toby.hocking@r-project.org
+
+      - name: run PDF renderer test
+        run: Rscript -e 'testthat::test_file("tests/testthat/test-renderer3-knit-print-pdf.R")'
 
       - name: run CRAN build
         run: bash build.sh

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Changes in version 2026.8.18 (issue #254)
+
+- Codecov now uploads R and JavaScript coverage together, and only after both coverage jobs succeed, so a failed JS (or R) job cannot become an incomplete project-coverage baseline.
+
 # Changes in version 2026.6.28 (PR#328)
 
 - New tooltipID(), mouseMoved(), mousePressed(), mouseReleased() helper functions in tests/testthat/helper-functions.R for simulating mouse events and checking tooltip elements in renderer tests.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# Changes in version 2026.8.18 (issue #254)
+# Changes in version 2026.8.18 (PR#344)
 
 - Codecov now uploads R and JavaScript coverage together, and only after both coverage jobs succeed, so a failed JS (or R) job cannot become an incomplete project-coverage baseline.
 

--- a/tests/testthat/test-renderer3-knit-print-pdf.R
+++ b/tests/testthat/test-renderer3-knit-print-pdf.R
@@ -1,4 +1,5 @@
 acontext("render animint in pdf")
+skip_if_not(nzchar(Sys.which("pdflatex")), "pdflatex not available")
 knitr::knit_meta() #clear knitr 'metadata'
 screenshot.Rmd <- system.file(
   "examples", "test_knit_print_screenshot.Rmd",


### PR DESCRIPTION
Fixes #254

## Summary
- Codecov `project` was failing on documentation-only commits because R and JS coverage were uploaded separately. If the JS job failed, an R-only report became the baseline, so the next full R+JS upload looked like a coverage drop.
- Coverage jobs now save artifacts instead of uploading immediately. A follow-up job uploads both reports together, and only if both R and JS jobs succeed.
- CRAN checks stay in their own job. Texlive is installed only there.

## Test plan
- [ ] Confirm CI runs `R_coverage` and `JS_coverage` in parallel, then `Upload combined coverage to Codecov`.
- [ ] Confirm the combined upload job is skipped if either coverage job fails.
- [ ] Confirm CRAN still runs independently.
- [ ] On the PR, Codecov `patch` and `project` should not fail just because one coverage job failed on a previous commit.